### PR TITLE
Make sure project .dbtwiz directory exists prior to use.

### DIFF
--- a/dbtwiz/build.py
+++ b/dbtwiz/build.py
@@ -108,7 +108,6 @@ class Build():
 
     @classmethod
     def save_selected_models(cls, models):
-        Path.mkdir(project_dbtwiz_path(), exist_ok=True)
         with open(cls.LAST_SELECT_FILE, "w+") as f:
             f.write(json.dumps(models))
 

--- a/dbtwiz/config.py
+++ b/dbtwiz/config.py
@@ -28,6 +28,8 @@ def project_path(target: str = "") -> Path:
 
 def project_dbtwiz_path(target: str = "") -> Path:
     """Get Path to the given target relative to the project .dbtwiz directory"""
+    dot_path = project_config().root_path() / ".dbtwiz"
+    Path.mkdir(dot_path, exist_ok=True)
     return project_config().root_path() / ".dbtwiz" / target
 
 

--- a/dbtwiz/manifest.py
+++ b/dbtwiz/manifest.py
@@ -17,7 +17,7 @@ from .support import models_with_local_changes
 class Manifest:
 
     MANIFEST_PATH = Path(".", "target", "manifest.json")
-    PROD_MANIFEST_PATH = project_dbtwiz_path() / "prod-state" / "prod-manifest.json"
+    PROD_MANIFEST_PATH = project_dbtwiz_path() / "prod-state" / "manifest.json"
     MODELS_CACHE_PATH = project_dbtwiz_path("models-cache.json")
     MODELS_INFO_PATH = project_dbtwiz_path("models")
 

--- a/dbtwiz/manifest.py
+++ b/dbtwiz/manifest.py
@@ -17,7 +17,7 @@ from .support import models_with_local_changes
 class Manifest:
 
     MANIFEST_PATH = Path(".", "target", "manifest.json")
-    PROD_MANIFEST_PATH = project_dbtwiz_path("prod-manifest.json")
+    PROD_MANIFEST_PATH = project_dbtwiz_path() / "prod-state" / "prod-manifest.json"
     MODELS_CACHE_PATH = project_dbtwiz_path("models-cache.json")
     MODELS_INFO_PATH = project_dbtwiz_path("models")
 
@@ -48,7 +48,7 @@ class Manifest:
         gcs = storage.Client(project=project_config().gcp_project)
         blob = gcs.bucket(project_config().dbt_state_bucket).blob("manifest.json")
         # Create path if missing
-        Path(project_dbtwiz_path()).mkdir(parents=True, exist_ok=True)
+        cls.PROD_MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
         # Download prod manifest to path
         blob.download_to_filename(cls.PROD_MANIFEST_PATH)
         gcs.close()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dbtwiz",
-    version="0.1.7",
+    version="0.1.8",
     author="Amedia Produkt og Teknologi",
     url="https://github.com/amedia/dbtwiz",
     license="MIT",


### PR DESCRIPTION
Fix for issue https://github.com/amedia/dbtwiz/issues/24.
Also, use `{PROJECT_ROOT}/.dbtwiz/prod-state/manifest.json` as path for production manifest.