### PR TITLE
Refactor: Changed to `model create` and `source create` + corrected bugs

### DIFF
--- a/dbtwiz/commands/__init__.py
+++ b/dbtwiz/commands/__init__.py
@@ -1,3 +1,8 @@
+import datetime
+
+import typer
+from typing import Annotated
+
 from .backfill import backfill
 from .build import build
 from .config import config
@@ -5,3 +10,234 @@ from .freshness import freshness
 from .manifest import manifest
 from .precommit import sqlfix
 from .test import test
+from dbtwiz.target import Target
+
+app = typer.Typer()
+
+
+class InvalidArgumentsError(ValueError):
+    pass
+
+
+@app.command()
+def build(
+    target: Annotated[
+        Target, typer.Option("--target", "-t", help="Target")
+    ] = Target.dev,
+    select: Annotated[
+        str, typer.Option("--select", "-s", help="Model selector passed to dbt")
+    ] = "",
+    date: Annotated[
+        str, typer.Option("--date", help="Date to run model on [YYYY-mm-dd]")
+    ] = "",
+    use_task_index: Annotated[
+        bool,
+        typer.Option(
+            "--use-task-index",
+            help=("Use task index passed by Cloud Run env as an offset to the date"),
+        ),
+    ] = False,
+    save_state: Annotated[
+        bool,
+        typer.Option(
+            "--save-state",
+            help=(
+                "Save state by uploading the manifest file to the "
+                "state bucket after a successful run"
+            ),
+        ),
+    ] = False,
+    full_refresh: Annotated[
+        bool,
+        typer.Option(
+            "--full-refresh", "-f", help="Force full refresh when building the model"
+        ),
+    ] = False,
+    upstream: Annotated[
+        bool,
+        typer.Option(
+            "--upstream",
+            "-u",
+            help="Include building of upstream dependencies of the selected models",
+        ),
+    ] = False,
+    downstream: Annotated[
+        bool,
+        typer.Option(
+            "--downstream",
+            "-d",
+            help="Include building of downstream dependencies of the selected models",
+        ),
+    ] = False,
+    work: Annotated[
+        bool,
+        typer.Option(
+            "--work",
+            "-w",
+            help="Consider only new or changed models for interactive selection",
+        ),
+    ] = False,
+    repeat_last: Annotated[
+        bool, typer.Option("--last", "-l", help="Build the last built models again")
+    ] = False,
+) -> None:
+    """Build dbt models"""
+    # Validate
+    try:
+        if date == "":
+            run_date = datetime.date.today()
+        else:
+            run_date = datetime.date.fromisoformat(date)
+    except ValueError:
+        raise InvalidArgumentsError("Date must be on the YYYY-mm-dd format.")
+    # Dispatch
+    build(
+        target.value,
+        select,
+        run_date,
+        use_task_index,
+        save_state,
+        full_refresh,
+        upstream,
+        downstream,
+        work,
+        repeat_last,
+    )
+
+
+@app.command()
+def test(
+    target: Annotated[
+        Target, typer.Option("--target", "-t", help="Target")
+    ] = Target.dev,
+    select: Annotated[
+        str, typer.Option("--select", "-s", help="Model selector passed to dbt")
+    ] = "",
+    date: Annotated[
+        str, typer.Option("--date", "-d", help="Date to test model on [YYYY-mm-dd]")
+    ] = "",
+) -> None:
+    """Test dbt models"""
+    # Validate
+    try:
+        if date == "":
+            run_date = datetime.date.today()
+        else:
+            run_date = datetime.date.fromisoformat(date)
+    except ValueError:
+        raise InvalidArgumentsError("Date must be on the YYYY-mm-dd format.")
+    # Dispatch
+    test(target.value, select, run_date)
+
+
+@app.command()
+def sqlfix():
+    """Run sqlfmt-fix and sqlfluff-fix on staged changes"""
+    sqlfix()
+
+
+@app.command()
+def manifest(
+    type: Annotated[
+        str,
+        typer.Option(
+            "--type",
+            "-t",
+            help="Which manifest to update. One of ['all', 'dev', 'prod']. Default 'all'.",
+        ),
+    ] = "all",
+):
+    """Update dev and production manifests for fast lookup"""
+    manifest(type)
+
+
+@app.command()
+def backfill(
+    select: Annotated[str, typer.Argument(help="Model selector passed to dbt")],
+    date_first: Annotated[
+        str, typer.Argument(help="Start of backfill period [YYYY-mm-dd]")
+    ],
+    date_last: Annotated[
+        str, typer.Argument(help="End of backfill period (inclusive) [YYYY-mm-dd]")
+    ],
+    full_refresh: Annotated[
+        bool,
+        typer.Option(
+            "--full-refresh",
+            "-f",
+            help=(
+                "Do a full refresh when building the model. "
+                "not supported when also building dependencies, "
+                "or when running over multiple days"
+            ),
+        ),
+    ] = False,
+    parallelism: Annotated[
+        int,
+        typer.Option(
+            "--parallelism",
+            "-p",
+            help=(
+                "Number of tasks to run in parallel. Set to 1 for serial processing, "
+                "useful for models that depend on their own past data where the "
+                "processing order is important."
+            ),
+        ),
+    ] = 8,
+    status: Annotated[
+        bool,
+        typer.Option(
+            "--status",
+            "-s",
+            help="Open job status page in browser after starting execution",
+        ),
+    ] = True,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Output more info about what is going on"),
+    ] = False,
+) -> None:
+    """Backfill dbt models by generating job spec and execute through Cloud Run"""
+    # Validate
+    try:
+        first_date = datetime.date.fromisoformat(date_first)
+        last_date = datetime.date.fromisoformat(date_last)
+    except ValueError:
+        raise InvalidArgumentsError("Dates must be on the YYYY-mm-dd format.")
+    if date_last < date_first:
+        raise InvalidArgumentsError("Last date must be on or after first date.")
+    if full_refresh:
+        if "+" in select:
+            raise InvalidArgumentsError(
+                "Full refresh is only supported on single models."
+            )
+        if date_last != date_first:
+            raise InvalidArgumentsError(
+                "Full refresh in only supported on single day runs."
+            )
+    # Dispatch
+    backfill(select, first_date, last_date, full_refresh, parallelism, status, verbose)
+
+
+@app.command()
+def freshness(
+    target: Annotated[
+        Target,
+        typer.Option(
+            "--target",
+            "-t",  # does this have any function when checking sources?
+            help="Target",
+        ),
+    ] = Target.dev,
+) -> None:
+    """Run source freshness tests"""
+    freshness(target.value)
+
+
+@app.command()
+def config(
+    setting: Annotated[str, typer.Argument(help="Configuration setting")],
+    value: Annotated[str, typer.Argument(help="Configuration value")],
+):
+    """Update configuration setting"""
+    config(setting, value)

--- a/dbtwiz/commands/__init__.py
+++ b/dbtwiz/commands/__init__.py
@@ -3,6 +3,5 @@ from .build import build
 from .config import config
 from .freshness import freshness
 from .manifest import manifest
-from .model import model
 from .precommit import sqlfix
 from .test import test

--- a/dbtwiz/main.py
+++ b/dbtwiz/main.py
@@ -5,7 +5,8 @@ from typing import Annotated
 
 from dbtwiz import admin
 from dbtwiz import commands
-from dbtwiz import create
+from dbtwiz import model
+from dbtwiz import source
 from dbtwiz.logging import error
 from dbtwiz.target import Target
 
@@ -23,8 +24,11 @@ app = typer.Typer(
 # Add admin commands as subcommands of 'admin'
 app.add_typer(admin.app, name="admin", help="Administrative commands")
 
-# Add creation commands as subcommands of 'create'
-app.add_typer(create.app, name="create", help="Commands for creating new dbt models and sources")
+# Add model commands as subcommands of 'model'
+app.add_typer(model.app, name="model", help="Commands for dbt models")
+
+# Add source commands as subcommands of 'source'
+app.add_typer(source.app, name="source", help="Commands for dbt sources")
 
 
 @app.command()

--- a/dbtwiz/main.py
+++ b/dbtwiz/main.py
@@ -1,199 +1,35 @@
-import datetime
-
 import typer
-from typing import Annotated
 
 from dbtwiz import admin
 from dbtwiz import commands
 from dbtwiz import model
 from dbtwiz import source
 from dbtwiz.logging import error
-from dbtwiz.target import Target
-
-
-class InvalidArgumentsError(ValueError):
-    pass
 
 
 app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
-    #add_completion=False,
+    # add_completion=False,
 )
 
 
-# Add admin commands as subcommands of 'admin'
-app.add_typer(admin.app, name="admin", help="Administrative commands")
-
 # Add model commands as subcommands of 'model'
-app.add_typer(model.app, name="model", help="Commands for dbt models")
+app.add_typer(model.app, name="model", help="Commands for a dbt model")
 
 # Add source commands as subcommands of 'source'
-app.add_typer(source.app, name="source", help="Commands for dbt sources")
+app.add_typer(source.app, name="source", help="Commands for a dbt source")
 
+# Add general commands
+app.add_typer(commands.app)
 
-@app.command()
-def build(
-        target: Annotated[Target, typer.Option(
-            "--target", "-t",
-            help="Target")] = Target.dev,
-        select: Annotated[str, typer.Option(
-            "--select", "-s",
-            help="Model selector passed to dbt")] = "",
-        date: Annotated[str, typer.Option(
-            "--date",
-            help="Date to run model on [YYYY-mm-dd]")] = "",
-        use_task_index: Annotated[bool, typer.Option(
-            "--use-task-index",
-            help=("Use task index passed by Cloud Run env as an "
-                  "offset to the date"))] = False,
-        save_state: Annotated[bool, typer.Option(
-            "--save-state",
-            help=("Save state by uploading the manifest file to the "
-                  "state bucket after a successful run"))] = False,
-        full_refresh: Annotated[bool, typer.Option(
-            "--full-refresh", "-f",
-            help="Force full refresh when building the model")] = False,
-        upstream: Annotated[bool, typer.Option(
-            "--upstream", "-u",
-            help="Include building of upstream dependencies of the selected models")] = False,
-        downstream: Annotated[bool, typer.Option(
-            "--downstream", "-d",
-            help="Include building of downstream dependencies of the selected models")] = False,
-        work: Annotated[bool, typer.Option(
-            "--work", "-w",
-            help="Consider only new or changed models for interactive selection")] = False,
-        repeat_last: Annotated[bool, typer.Option(
-            "--last", "-l",
-            help="Build the last built models again")] = False,
-) -> None:
-    """Build dbt models"""
-    # Validate
-    try:
-        if date == "":
-            run_date = datetime.date.today()
-        else:
-            run_date = datetime.date.fromisoformat(date)
-    except ValueError:
-        raise InvalidArgumentsError("Date must be on the YYYY-mm-dd format.")
-    # Dispatch
-    commands.build(
-        target.value, select, run_date, use_task_index, save_state,
-        full_refresh, upstream, downstream, work, repeat_last
-    )
-
-
-@app.command()
-def test(
-        target: Annotated[Target, typer.Option(
-            "--target", "-t",
-            help="Target")] = Target.dev,
-        select: Annotated[str, typer.Option(
-            "--select", "-s",
-            help="Model selector passed to dbt")] = "",
-        date: Annotated[str, typer.Option(
-            "--date", "-d",
-            help="Date to test model on [YYYY-mm-dd]")] = "",
-) -> None:
-    """Test dbt models"""
-    # Validate
-    try:
-        if date == "":
-            run_date = datetime.date.today()
-        else:
-            run_date = datetime.date.fromisoformat(date)
-    except ValueError:
-        raise InvalidArgumentsError("Date must be on the YYYY-mm-dd format.")
-    # Dispatch
-    commands.test(target.value, select, run_date)
-
-
-@app.command()
-def freshness(
-        target: Annotated[Target, typer.Option(
-            "--target", "-t",  # does this have any function when checking sources?
-            help="Target")] = Target.dev,
-) -> None:
-    """Run source freshness tests"""
-    commands.freshness(target.value)
-
-
-@app.command()
-def backfill(
-        select: Annotated[str, typer.Argument(
-            help="Model selector passed to dbt")],
-        date_first: Annotated[str, typer.Argument(
-            help="Start of backfill period [YYYY-mm-dd]")],
-        date_last: Annotated[str, typer.Argument(
-            help="End of backfill period (inclusive) [YYYY-mm-dd]")],
-        full_refresh: Annotated[bool, typer.Option(
-            "--full-refresh", "-f",
-            help=("Do a full refresh when building the model. "
-                  "not supported when also building dependencies, "
-                  "or when running over multiple days"))] = False,
-        parallelism: Annotated[int, typer.Option(
-            "--parallelism", "-p",
-            help=("Number of tasks to run in parallel. Set to 1 for serial processing, "
-                  "useful for models that depend on their own past data where the "
-                  "processing order is important."))] = 8,
-        status: Annotated[bool, typer.Option(
-            "--status", "-s",
-            help="Open job status page in browser after starting execution")] = True,
-        verbose: Annotated[bool, typer.Option(
-            "--verbose", "-v",
-            help="Output more info about what is going on")] = False,
-) -> None:
-    """Backfill dbt models by generating job spec and execute through Cloud Run"""
-    # Validate
-    try:
-        first_date = datetime.date.fromisoformat(date_first)
-        last_date = datetime.date.fromisoformat(date_last)
-    except ValueError:
-        raise InvalidArgumentsError("Dates must be on the YYYY-mm-dd format.")
-    if date_last < date_first:
-        raise InvalidArgumentsError("Last date must be on or after first date.")
-    if full_refresh:
-        if '+' in select:
-            raise InvalidArgumentsError("Full refresh is only supported on single models.")
-        if date_last != date_first:
-            raise InvalidArgumentsError("Full refresh in only supported on single day runs.")
-    # Dispatch
-    commands.backfill(
-        select, first_date, last_date, full_refresh,
-        parallelism, status, verbose
-    )
-
-
-@app.command()
-def sqlfix():
-    """Run sqlfmt-fix and sqlfluff-fix on staged changes"""
-    commands.sqlfix()
-
-
-@app.command()
-def manifest(
-        type: Annotated[str, typer.Option(
-        "--type", "-t",
-        help="Which manifest to update. One of ['all', 'dev', 'prod']. Default 'all'.")] = "all",
-):
-    """Update dev and production manifests for fast lookup"""
-    commands.manifest(type)
-
-
-@app.command()
-def config(
-        setting: Annotated[str, typer.Argument(
-            help="Configuration setting")],
-        value: Annotated[str, typer.Argument(
-            help="Configuration value")],
-):
-    """Update configuration setting"""
-    commands.config(setting, value)
+# Add admin commands as subcommands of 'admin'
+app.add_typer(admin.app, name="admin", help="Administrative commands")
 
 
 # if __name__ == "__main__":
 def main():
     try:
         app()
-    except InvalidArgumentsError as err:
+    except commands.InvalidArgumentsError as err:
         error(f"ERROR: Invalid arguments - {err}")
         exit(1)

--- a/dbtwiz/main.py
+++ b/dbtwiz/main.py
@@ -164,15 +164,6 @@ def backfill(
 
 
 @app.command()
-def model(
-        name: Annotated[str, typer.Argument(
-            help="Model name or path")],
-):
-    """Output information about a given model"""
-    commands.model(name)
-
-
-@app.command()
 def sqlfix():
     """Run sqlfmt-fix and sqlfluff-fix on staged changes"""
     commands.sqlfix()

--- a/dbtwiz/model/__init__.py
+++ b/dbtwiz/model/__init__.py
@@ -3,6 +3,7 @@ from typing import Annotated, List
 import typer
 
 from .create import create_model
+from .inspect import inspect_model
 
 app = typer.Typer()
 
@@ -109,3 +110,16 @@ def create(
         service_consumers,
         access_policy,
     )
+
+
+@app.command()
+def inspect(
+    name: Annotated[
+        str,
+        typer.Option(
+            "--name", "-n", help="Model name or path"
+        ),
+    ],
+):
+    """Output information about a given model"""
+    inspect_model(name)

--- a/dbtwiz/model/__init__.py
+++ b/dbtwiz/model/__init__.py
@@ -2,14 +2,13 @@ from typing import Annotated, List
 
 import typer
 
-from .model import create_model
-from .source import create_source
+from .create import create_model
 
 app = typer.Typer()
 
 
 @app.command()
-def model(
+def create(
     quick: Annotated[
         bool,
         typer.Option(
@@ -109,60 +108,4 @@ def model(
         frequency,
         service_consumers,
         access_policy,
-    )
-
-
-@app.command()
-def source(
-    source_name: Annotated[
-        str,
-        typer.Option(
-            "--source_name",
-            "-s",
-            help="Where the source is located (existing alias used for project+dataset combination)",
-        ),
-    ] = None,
-    source_description: Annotated[
-        str,
-        typer.Option(
-            "--source-description",
-            "-sd",
-            help="A short description for the project+dataset combination (if this combination is new)",
-        ),
-    ] = None,
-    project_name: Annotated[
-        str,
-        typer.Option(
-            "--project-name", "-p", help="In which project the table is located"
-        ),
-    ] = None,
-    dataset_name: Annotated[
-        str,
-        typer.Option(
-            "--dataset-name", "-d", help="In which dataset the table is located"
-        ),
-    ] = None,
-    table_names: Annotated[
-        List[str],
-        typer.Option(
-            "--table-name", "-t", help="Name(s) of table(s) to be added as source(s)"
-        ),
-    ] = None,
-    table_description: Annotated[
-        str,
-        typer.Option(
-            "--table-description",
-            "-td",
-            help="A short description for the table, if only one is provided",
-        ),
-    ] = None,
-):
-    """Create new dbt source"""
-    create_source(
-        source_name,
-        source_description,
-        project_name,
-        dataset_name,
-        table_names,
-        table_description,
     )

--- a/dbtwiz/model/__init__.py
+++ b/dbtwiz/model/__init__.py
@@ -116,9 +116,7 @@ def create(
 def inspect(
     name: Annotated[
         str,
-        typer.Option(
-            "--name", "-n", help="Model name or path"
-        ),
+        typer.Option("--name", "-n", help="Model name or path"),
     ],
 ):
     """Output information about a given model"""

--- a/dbtwiz/model/create.py
+++ b/dbtwiz/model/create.py
@@ -12,7 +12,7 @@ from dbtwiz.interact import (
     select_from_list,
 )
 from dbtwiz.logging import fatal, info, warn
-from dbtwiz.model import (
+from dbtwiz.project import (
     Group,
     Project,
     access_choices,
@@ -188,10 +188,7 @@ def select_materialization(context):
         )
         context["materialization"] = "view"
         return
-    elif (
-        not context.get("materialization")
-        and context["layer"] == "staging"
-    ):
+    elif not context.get("materialization") and context["layer"] == "staging":
         info(
             "Setting materialization to view, which is required for all staging models."
         )
@@ -269,19 +266,14 @@ def select_frequency(context):
         del context["frequency"]
         return
     elif context.get("frequency") and context.get("materialization") == "view":
-        info(
-            "Ignoring defined frequency since frequency is not applicable for views."
-        )
+        info("Ignoring defined frequency since frequency is not applicable for views.")
         del context["frequency"]
         return
     elif context.get("materialization") == "view" or context.get("layer") == "staging":
         return
 
     valid_frequencies = frequency_choices()
-    if (
-        len(set(context["team"]) & set(["team-ai", "team-ai-analyst", "team-abo"]))
-        > 0
-    ):
+    if len(set(context["team"]) & set(["team-ai", "team-ai-analyst", "team-abo"])) > 0:
         valid_frequencies.append(
             {
                 "name": "daily_news_cycle",

--- a/dbtwiz/model/inspect.py
+++ b/dbtwiz/model/inspect.py
@@ -1,7 +1,7 @@
-import os
+# import os
 
 from textwrap import dedent
-from rich.console import Console
+# from rich.console import Console
 
 from dbtwiz.manifest import Manifest
 from dbtwiz.logging import error

--- a/dbtwiz/model/inspect.py
+++ b/dbtwiz/model/inspect.py
@@ -8,7 +8,6 @@ from dbtwiz.logging import error
 
 
 def inspect_model(name: str) -> None:
-
     models = Manifest.models_cached()
     if name not in models.keys():
         name = Manifest.choose_models(name, multi=False)
@@ -21,13 +20,21 @@ def inspect_model(name: str) -> None:
     model = manifest.model_by_name(name)
     # print(Manifest().model_info_template().render(model=model))
 
-    ancestors = sorted([m[0].split(".")[-1]
-                        for m in manifest.model_dependencies_upstream(f"model.dbt_core.{name}")],
-                       key=manifest.model_ordering)
+    ancestors = sorted(
+        [
+            m[0].split(".")[-1]
+            for m in manifest.model_dependencies_upstream(f"model.dbt_core.{name}")
+        ],
+        key=manifest.model_ordering,
+    )
 
-    descendants = sorted([m[0].split(".")[-1]
-                          for m in manifest.model_dependencies_downstream(f"model.dbt_core.{name}")],
-                       key=manifest.model_ordering)
+    descendants = sorted(
+        [
+            m[0].split(".")[-1]
+            for m in manifest.model_dependencies_downstream(f"model.dbt_core.{name}")
+        ],
+        key=manifest.model_ordering,
+    )
 
     if len(ancestors) > 0:
         print("Ancestors:")

--- a/dbtwiz/model/inspect.py
+++ b/dbtwiz/model/inspect.py
@@ -7,7 +7,7 @@ from dbtwiz.manifest import Manifest
 from dbtwiz.logging import error
 
 
-def model(name: str) -> None:
+def inspect_model(name: str) -> None:
 
     models = Manifest.models_cached()
     if name not in models.keys():

--- a/dbtwiz/project.py
+++ b/dbtwiz/project.py
@@ -72,6 +72,33 @@ class Project:
         ]
 
 
+class ModelBasePath:
+    """Path to model files (without suffix)"""
+
+    def __init__(self, layer: str):
+        self.layer = layer
+        self.layer_folder, self.layer_abbreviation = self.get_layer_details(layer)
+
+    def get_layer_details(self, layer: str):
+        layer_details = {
+            "staging": ("1_staging", "stg"),
+            "intermediate": ("2_intermediate", "int"),
+            "marts": ("3_marts", "mrt"),
+            "bespoke": ("4_bespoke", "bsp")
+        }
+        if layer not in layer_details:
+            raise ValueError(f"Invalid layer: {layer}")
+        return layer_details[layer]
+
+    def get_path(self, domain: str, name: str) -> Path:
+        path = project_path() / "models" / self.layer_folder / domain / f"{self.layer_abbreviation}_{domain}__{name}"
+        return path
+
+    def get_prefix(self, domain: str) -> str:
+        prefix = f"{self.layer_abbreviation}_{domain}__"
+        return prefix
+
+
 def layer_choices() -> List[Dict[str, str]]:
     """Dict of dbt layers and descriptions"""
     return [
@@ -175,19 +202,3 @@ def domains_for_layer(layer: str):
     """List of domains in the given layer for this project"""
     domains = [f.name for f in (project_path() / "models").glob(f"*_{layer}/*")]
     return sorted(domains)
-
-
-def model_base_path(layer: str, domain: str, name: str) -> Path:
-    """Path to model files (without suffix)"""
-    path = project_path() / "models"
-    if layer == "staging":
-        path = path / "1_staging" / domain / f"stg_{domain}__{name}"
-    elif layer == "intermediate":
-        path = path / "2_intermediate" / domain / f"int_{domain}__{name}"
-    elif layer == "marts":
-        path = path / "3_marts" / domain / f"mrt_{domain}__{name}"
-    elif layer == "bespoke":
-        path = path / "4_bespoke" / domain / f"bsp_{domain}__{name}"
-    else:
-        fatal(f"Invalid layer: [red]{layer}[/]")
-    return path

--- a/dbtwiz/source/__init__.py
+++ b/dbtwiz/source/__init__.py
@@ -1,0 +1,63 @@
+from typing import Annotated, List
+
+import typer
+
+from .create import create_source
+
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    source_name: Annotated[
+        str,
+        typer.Option(
+            "--source_name",
+            "-s",
+            help="Where the source is located (existing alias used for project+dataset combination)",
+        ),
+    ] = None,
+    source_description: Annotated[
+        str,
+        typer.Option(
+            "--source-description",
+            "-sd",
+            help="A short description for the project+dataset combination (if this combination is new)",
+        ),
+    ] = None,
+    project_name: Annotated[
+        str,
+        typer.Option(
+            "--project-name", "-p", help="In which project the table is located"
+        ),
+    ] = None,
+    dataset_name: Annotated[
+        str,
+        typer.Option(
+            "--dataset-name", "-d", help="In which dataset the table is located"
+        ),
+    ] = None,
+    table_names: Annotated[
+        List[str],
+        typer.Option(
+            "--table-name", "-t", help="Name(s) of table(s) to be added as source(s)"
+        ),
+    ] = None,
+    table_description: Annotated[
+        str,
+        typer.Option(
+            "--table-description",
+            "-td",
+            help="A short description for the table, if only one is provided",
+        ),
+    ] = None,
+):
+    """Create new dbt source"""
+    create_source(
+        source_name,
+        source_description,
+        project_name,
+        dataset_name,
+        table_names,
+        table_description,
+    )

--- a/dbtwiz/source/create.py
+++ b/dbtwiz/source/create.py
@@ -19,7 +19,7 @@ from dbtwiz.interact import (
     select_from_list,
 )
 from dbtwiz.logging import fatal, info, warn
-from dbtwiz.model import get_source_tables
+from dbtwiz.project import get_source_tables
 
 
 def get_existing_source(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dbtwiz",
-    version="0.2.1",
+    version="0.2.2",
     author="Amedia Produkt og Teknologi",
     url="https://github.com/amedia/dbtwiz",
     license="MIT",


### PR DESCRIPTION
- changed to `model create` and `source create` (from `create model` and `create source`)
- refactored commands for consistency, incl. move original model commands as `model inspect`
- materialization was pre-defined as `view` if not provided as parameter, which was incorrect
- the order of questions was changed to make more sense
- if materialization is `view` then frequency is not applicable and is thus skipped
- added check to hinder model prefix being provided with model name input
- corrected typo in message when cancelling
- updated patch version to `0.2.2`

The new order of `dbtwiz` functions is now:
![image](https://github.com/user-attachments/assets/46afcf42-018a-417b-9448-993d1614ef74)

While for `dbtwiz model` it is:
![image](https://github.com/user-attachments/assets/5120f195-9c15-4943-8d14-02c6a1bed740)