### PR TITLE
Feature: Admin submodule for updating mismatched partition expiries

### DIFF
--- a/dbtwiz/admin/__init__.py
+++ b/dbtwiz/admin/__init__.py
@@ -1,8 +1,9 @@
-import typer
 from typing import Annotated, List
 
+import typer
 from dbtwiz.logging import error
 from dbtwiz.target import Target
+
 
 class InvalidArgumentsError(ValueError):
     pass
@@ -13,44 +14,62 @@ app = typer.Typer()
 
 @app.command()
 def orphaned(
-        target: Annotated[Target, typer.Option(
-            "--target", "-t",
-            help="Target")] = Target.dev,
-        list_only: Annotated[bool, typer.Option(
-            "--list", "-l",
-            help=("List orphaned materializations without deleting anything"))] = False,
-        force_delete: Annotated[bool, typer.Option(
-            "--force", "-f",
-            help=("Delete orphaned materializations without asking (dev target only)"))] = False,
+    target: Annotated[
+        Target, typer.Option("--target", "-t", help="Target")
+    ] = Target.dev,
+    list_only: Annotated[
+        bool,
+        typer.Option(
+            "--list",
+            "-l",
+            help=("List orphaned materializations without deleting anything"),
+        ),
+    ] = False,
+    force_delete: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help=("Delete orphaned materializations without asking (dev target only)"),
+        ),
+    ] = False,
 ) -> None:
     """List or delete orphaned materializations in the data warehouse"""
     if list_only and force_delete:
         error("You can't both list and force-delete at the same time.")
     else:
         from .cleanup import handle_orphaned_materializations
+
         handle_orphaned_materializations(target, list_only, force_delete)
 
 
 @app.command()
 def cleandev(
-        force_delete: Annotated[bool, typer.Option(
-            "--force", "-f",
-            help=("Delete without asking for confirmation first"))] = False,
+    force_delete: Annotated[
+        bool,
+        typer.Option(
+            "--force", "-f", help=("Delete without asking for confirmation first")
+        ),
+    ] = False,
 ) -> None:
     """Delete all materializations in the dbt development dataset"""
     from .cleanup import empty_development_dataset
+
     empty_development_dataset(force_delete)
 
 
 @app.command()
 def partition_expiry(
-        model_names: Annotated[
+    model_names: Annotated[
         List[str],
         typer.Option(
-            "--model-name", "-m", help="Name of model to be checked for partition expiry"
+            "--model-name",
+            "-m",
+            help="Name of model to be checked for partition expiry",
         ),
     ] = None,
 ) -> None:
     """Checks for mismatched partition expiry and allows updating to correct."""
     from .partition import update_partition_expirations
+
     update_partition_expirations(model_names)

--- a/dbtwiz/admin/__init__.py
+++ b/dbtwiz/admin/__init__.py
@@ -47,7 +47,7 @@ def partition_expiry(
         model_names: Annotated[
         List[str],
         typer.Option(
-            "--model-name", "-m", help="Name(s) of model(s) to be checked for partition expiry"
+            "--model-name", "-m", help="Name of model to be checked for partition expiry"
         ),
     ] = None,
 ) -> None:

--- a/dbtwiz/admin/__init__.py
+++ b/dbtwiz/admin/__init__.py
@@ -40,3 +40,10 @@ def cleandev(
     """Delete all materializations in the dbt development dataset"""
     from .cleanup import empty_development_dataset
     empty_development_dataset(force_delete)
+
+
+@app.command()
+def partition_expiry() -> None:
+    """Checks for mismatched partition expiry and allows updating to correct."""
+    from .partition import update_partition_expirations
+    update_partition_expirations()

--- a/dbtwiz/admin/__init__.py
+++ b/dbtwiz/admin/__init__.py
@@ -1,5 +1,5 @@
 import typer
-from typing_extensions import Annotated
+from typing import Annotated, List
 
 from dbtwiz.logging import error
 from dbtwiz.target import Target
@@ -43,7 +43,14 @@ def cleandev(
 
 
 @app.command()
-def partition_expiry() -> None:
+def partition_expiry(
+        model_names: Annotated[
+        List[str],
+        typer.Option(
+            "--model-name", "-m", help="Name(s) of model(s) to be checked for partition expiry"
+        ),
+    ] = None,
+) -> None:
     """Checks for mismatched partition expiry and allows updating to correct."""
     from .partition import update_partition_expirations
-    update_partition_expirations()
+    update_partition_expirations(model_names)

--- a/dbtwiz/admin/cleanup.py
+++ b/dbtwiz/admin/cleanup.py
@@ -34,7 +34,7 @@ def empty_development_dataset(force_delete: bool) -> None:
     for table in tables:
         table_type = table.table_type.lower()
         try:
-            client.delete_bq_table(table, project)
+            client.delete_table(table, project)
             info(f"Deleted {table_type} {project}.{dataset}.{table.table_id}")
         except Exception as e:
             error(
@@ -77,7 +77,7 @@ def handle_orphaned_materializations(
     # Add existing materializations in DWH by querying information schema
     for project, datasets in data.items():
         info(f"Fetching datasets and tables for project {project}")
-        result = client.run_bq_query(
+        result = client.run_query(
             project,
             f"""
             select table_schema, array_agg(table_name) as tables
@@ -120,5 +120,5 @@ def handle_orphaned_materializations(
             answer = input("Delete (y/N)? ")
             delete = answer.lower() in ["y", "yes"]
         if delete:
-            client.delete_bq_table(table_id)
+            client.delete_table(table_id)
             info(f"Deleted {table_id}.")

--- a/dbtwiz/admin/cleanup.py
+++ b/dbtwiz/admin/cleanup.py
@@ -34,7 +34,7 @@ def empty_development_dataset(force_delete: bool) -> None:
     for table in tables:
         table_type = table.table_type.lower()
         try:
-            client.delete_bq_table(table)
+            client.delete_bq_table(table, project)
             info(f"Deleted {table_type} {project}.{dataset}.{table.table_id}")
         except Exception as e:
             error(

--- a/dbtwiz/admin/partition.py
+++ b/dbtwiz/admin/partition.py
@@ -54,7 +54,7 @@ def find_mismatched_models(models: list, client: BigQueryClient) -> List[Dict[st
                 # Attributes used by questionary
                 "name": f"{table_id:<95} {current:>5} → {defined:>5} ({difference:>+1})",
                 "value": table_id,
-                "description": f"Current expiration is {current} days, while defined expiration is {defined} days",
+                "description": f"Current expiration is {current} days, defined expiration is {defined} days",
                 # Additional attribute used when updating selected tables
                 "defined_expiration": defined
             })

--- a/dbtwiz/admin/partition.py
+++ b/dbtwiz/admin/partition.py
@@ -64,7 +64,7 @@ def find_mismatched_models(models: list, client: BigQueryClient) -> List[Dict[st
 
 def update_partition_expirations():
     """Main function to compare and update partition expiration in BigQuery."""
-    # Update and get the prod manifest
+    # Update and read the prod manifest
     Manifest.update_manifests("prod")
     prod_manifest = Manifest.get_manifest(Manifest.PROD_MANIFEST_PATH)
 
@@ -93,7 +93,6 @@ def update_partition_expirations():
         # Update selected tables
         for table_id in selected_tables:
             model = next(model for model in mismatched_models if model.get("value") == table_id)
-            print(f"Updating model {model}")
-            # client.update_bigquery_partition_expiration(table_id, model["defined_expiration"])
+            client.update_bigquery_partition_expiration(table_id, model["defined_expiration"])
     else:
         print("No mismatched models found.")

--- a/dbtwiz/admin/partition.py
+++ b/dbtwiz/admin/partition.py
@@ -62,7 +62,9 @@ def find_mismatched_models(models: list, client: BigQueryClient) -> List[Dict[st
     return mismatched_models
 
 
-def update_partition_expirations():
+def update_partition_expirations(
+        model_names: List[str] = None,
+):
     """Main function to compare and update partition expiration in BigQuery."""
     # Update and read the prod manifest
     Manifest.update_manifests("prod")
@@ -76,6 +78,10 @@ def update_partition_expirations():
     # Identify models with partition expiration
     models = identify_models_with_partition_expiration(prod_manifest)
     models = resolve_partition_expiration(models, partition_vars)
+
+    # Filter models if model_names provided
+    if model_names:
+        models = [item for item in models if item['model_name'] in model_names]
 
     # Find mismatched models
     client = BigQueryClient()

--- a/dbtwiz/admin/partition.py
+++ b/dbtwiz/admin/partition.py
@@ -41,7 +41,6 @@ def find_mismatched_models(models: list, client: BigQueryClient) -> List[Dict[st
     """Find models where the defined expiration does not match the BigQuery expiration."""
     mismatched_models = []
     for model in models:
-        # print(f"Checking partition expiration for table: {model['table_id']}...")
         current_expiration = client.get_bigquery_partition_expiration(model["table_id"])
         if current_expiration != model["defined_expiration"]:
             table_id = model["table_id"]
@@ -55,6 +54,7 @@ def find_mismatched_models(models: list, client: BigQueryClient) -> List[Dict[st
                 # Attributes used by questionary
                 "name": f"{table_id:<95} {current:>5} → {defined:>5} ({difference:>+1})",
                 "value": table_id,
+                "description": f"Current expiration: {current} days, defined expiration: {defined} days",
                 # Additional attribute used when updating selected tables
                 "defined_expiration": defined
             })

--- a/dbtwiz/admin/partition.py
+++ b/dbtwiz/admin/partition.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 
 from dbtwiz.bigquery import BigQueryClient
 from dbtwiz.interact import multiselect_from_list
+from dbtwiz.logging import info
 from dbtwiz.manifest import Manifest
 
 # Initialize Typer CLI
@@ -62,11 +63,11 @@ def find_mismatched_models(models: list, client: BigQueryClient) -> List[Dict[st
 @app.command()
 def update_partition_expirations():
     """Main function to compare and update partition expiration in BigQuery."""
-    print("Checking for mismatched partition expirations...")
-
     # Update and get the prod manifest
     Manifest.update_manifests("prod")
     prod_manifest = Manifest.get_manifest(Manifest.PROD_MANIFEST_PATH)
+
+    info("Identifying mismatched partition expirations...")
 
     # Extract partition expiration variables from the prod manifest
     partition_vars = extract_partition_vars(prod_manifest)
@@ -89,12 +90,10 @@ def update_partition_expirations():
         )
 
         # Update selected tables
-        # if selected_tables and "skip" not in selected_tables:
-        #     for table_id in selected_tables:
-        #         model = next(model for model in mismatched_models if model["value"] == table_id)
-        #         update_bigquery_partition_expiration(client, table_id, model["defined_expiration"])
-        # else:
-        #     print("Operation canceled.")
+        for table_id in selected_tables:
+            model = next(model for model in mismatched_models if model.get("value") == table_id)
+            print(f"Updating model {model}")
+            # client.update_bigquery_partition_expiration(table_id, model["defined_expiration"])
     else:
         print("No mismatched models found.")
 

--- a/dbtwiz/admin/partition.py
+++ b/dbtwiz/admin/partition.py
@@ -1,0 +1,118 @@
+import typer
+
+from dbtwiz.bigquery import BigQueryClient
+from dbtwiz.interact import multiselect_from_list
+from dbtwiz.manifest import Manifest
+
+# Initialize Typer CLI
+app = typer.Typer()
+
+
+# Extract partition expiration variables from the manifest
+def extract_partition_vars(manifest: dict) -> dict:
+    """Extract partition expiration variables from the manifest."""
+    return manifest.get("metadata", {}).get("vars", {})
+
+# Identify models with partition expiration defined
+def identify_models_with_partition_expiration(manifest: dict) -> list:
+    """Identify models with partition_expiration_days defined in the manifest."""
+    models = []
+    for node_id, node in manifest["nodes"].items():
+        if node["resource_type"] == "model" and "config" in node and "partition_expiration_days" in node["config"]:
+            models.append({
+                "model_name": node["name"],
+                "table_id": f"{node['database']}.{node['schema']}.{node['alias']}",
+                "defined_expiration": node["config"]["partition_expiration_days"]
+            })
+    return models
+
+# Convert defined expiration to actual values using partition_vars
+def resolve_partition_expiration(models: list, partition_vars: dict) -> list:
+    """Resolve partition expiration values using variables from the manifest."""
+    for model in models:
+        if isinstance(model["defined_expiration"], str) and model["defined_expiration"].startswith("{{ var("):
+            var_name = model["defined_expiration"].split("'")[1]
+            model["defined_expiration"] = partition_vars.get(var_name, 0)
+    return models
+
+# Compare defined expiration with BigQuery expiration
+def find_mismatched_models(models: list, client: BigQueryClient) -> list:
+    """Find models where the defined expiration does not match the BigQuery expiration."""
+    mismatched_models = []
+    for model in models:
+        # print(f"Checking partition expiration for table: {model['table_id']}...")
+        current_expiration = client.get_bigquery_partition_expiration(model["table_id"])
+        if current_expiration != model["defined_expiration"]:
+            mismatched_models.append({
+                "table_id": model["table_id"],
+                "current_expiration": current_expiration,
+                "defined_expiration": model["defined_expiration"],
+                "difference": model["defined_expiration"] - current_expiration
+            })
+    return mismatched_models
+
+# Format mismatched models for display
+def format_mismatched_models(mismatched_models: list) -> list:
+    """Format mismatched models for display in a clean tabular format."""
+    formatted_choices = []
+    for model in mismatched_models:
+        table_id = model["table_id"]
+        current = model["current_expiration"]
+        defined = model["defined_expiration"]
+        difference = model["difference"]
+        # Align the numbers and arrows
+        formatted_choices.append(
+            {
+                "name": f"{table_id:<95} {current:>5} → {defined:>5} ({difference:>+1})",
+                "value": model["table_id"]
+            }
+        )
+    return formatted_choices
+
+@app.command()
+def update_partition_expirations():
+    """Main function to compare and update partition expiration in BigQuery."""
+    print("Checking for mismatched partition expirations...")
+
+    # Update and get the prod manifest
+    Manifest.update_manifests("prod")
+    prod_manifest = Manifest.get_manifest(Manifest.PROD_MANIFEST_PATH)
+
+    # Extract partition expiration variables from the prod manifest
+    partition_vars = extract_partition_vars(prod_manifest)
+
+    # Identify models with partition expiration
+    models = identify_models_with_partition_expiration(prod_manifest)
+    models = resolve_partition_expiration(models, partition_vars)
+
+    # Find mismatched models
+    client = BigQueryClient()
+    mismatched_models = find_mismatched_models(models, client)
+
+    # Present mismatched models to the user
+    if mismatched_models:
+        # Format the choices for questionary.checkbox
+        choices = format_mismatched_models(mismatched_models)
+        # Add "Skip update" option
+        choices.insert(0, {"name": "*** Skip update ***", "value": "skip"})
+
+        # Prompt user to select tables to update
+        selected_tables = multiselect_from_list(
+            "Select mismatched tables to update",
+            items=choices,
+            allow_none=False,
+        )
+
+        # Update selected tables
+        # if selected_tables and "skip" not in selected_tables:
+        #     for table_id in selected_tables:
+        #         model = next(model for model in mismatched_models if model["table_id"] == table_id)
+        #         update_bigquery_partition_expiration(client, table_id, model["defined_expiration"])
+        # else:
+        #     print("Operation canceled.")
+    else:
+        print("No mismatched models found.")
+
+# Run the CLI
+if __name__ == "__main__":
+    app()

--- a/dbtwiz/admin/partition.py
+++ b/dbtwiz/admin/partition.py
@@ -54,7 +54,7 @@ def find_mismatched_models(models: list, client: BigQueryClient) -> List[Dict[st
                 # Attributes used by questionary
                 "name": f"{table_id:<95} {current:>5} → {defined:>5} ({difference:>+1})",
                 "value": table_id,
-                "description": f"Current expiration is {current} days while defined expiration is {defined} days",
+                "description": f"Current expiration is {current} days, while defined expiration is {defined} days",
                 # Additional attribute used when updating selected tables
                 "defined_expiration": defined
             })

--- a/dbtwiz/admin/partition.py
+++ b/dbtwiz/admin/partition.py
@@ -54,7 +54,7 @@ def find_mismatched_models(models: list, client: BigQueryClient) -> List[Dict[st
                 # Attributes used by questionary
                 "name": f"{table_id:<95} {current:>5} → {defined:>5} ({difference:>+1})",
                 "value": table_id,
-                "description": f"Current expiration: {current} days, defined expiration: {defined} days",
+                "description": f"Current expiration is {current} days while defined expiration is {defined} days",
                 # Additional attribute used when updating selected tables
                 "defined_expiration": defined
             })

--- a/dbtwiz/bigquery.py
+++ b/dbtwiz/bigquery.py
@@ -1,144 +1,126 @@
-from importlib import import_module
 from typing import List, Tuple
 
 from ruamel.yaml.scalarstring import PreservedScalarString
 
 
-def import_module_once(parent, subpackage, submodule=None):
-    """Function to enable lazy import and only import once."""
-    full_module_name = f"{parent}.{subpackage}" if parent else subpackage
-    if full_module_name not in globals():
-        globals()[full_module_name] = import_module(full_module_name)
-    # If submodule is specified, get it from the imported module
-    if submodule:
-        return getattr(globals()[full_module_name], submodule)
-    return globals()[full_module_name]
+class BigQueryClient:
+    """Class for BigQuery client"""
+
+    def __init__(self):
+        """Initializes the class."""
+        from google.api_core.exceptions import Forbidden, NotFound
+        self.Forbidden = Forbidden
+        self.NotFound = NotFound
+        self._client = None
+
+    def get_client(self):
+        """Get or set the BigQuery client."""
+        if self._client is None:
+            from google.cloud import bigquery
+            self._client = bigquery.Client()
+        return self._client
 
 
-def import_common_modules():
-    """Import function for common packages."""
-    bigquery = import_module_once("google.cloud", "bigquery")
-    Forbidden = import_module_once("google.api_core", "exceptions", "Forbidden")
-    NotFound = import_module_once("google.api_core", "exceptions", "NotFound")
-    return bigquery, Forbidden, NotFound
+    def list_datasets_in_project(self, project) -> Tuple[List[str], str]:
+        """Fetch all datasets in the given project from BigQuery."""
+        try:
+            datasets = list(self.get_client().list_datasets(project=project))
+            return sorted([dataset.dataset_id for dataset in datasets]), ""
+        except Exception as e:
+            return [], f"Error: Failed to fetch datasets from BigQuery: {e}"
 
 
-def list_datasets_in_project(project) -> Tuple[List[str], str]:
-    """Fetch all datasets in the given project from BigQuery."""
-    bigquery = import_module_once("google.cloud", "bigquery")
-    client = bigquery.Client()
-    try:
-        datasets = list(client.list_datasets(project=project))
-        return sorted([dataset.dataset_id for dataset in datasets]), ""
-    except Exception as e:
-        return [], f"Error: Failed to fetch datasets from BigQuery: {e}"
+    def fetch_tables_in_dataset(self, project, dataset) -> Tuple[List[str], str]:
+        """Fetch all tables in the given project and dataset from BigQuery."""
+        dataset_ref = f"{project}.{dataset}"
+        try:
+            tables = list(self.get_client().list_tables(dataset_ref))
+            return [table.table_id for table in tables], ""
+        except self.NotFound:
+            return [], f"Error: The dataset '{dataset_ref}' does not exist in BigQuery."
+        except self.Forbidden:
+            return [], f"Error: You do not have access to the dataset '{dataset_ref}'."
+        except Exception as e:
+            return [], f"Error: Failed to fetch tables from BigQuery: {e}"
 
 
-def fetch_tables_in_dataset(project, dataset) -> Tuple[List[str], str]:
-    """Fetch all tables in the given project and dataset from BigQuery."""
-    bigquery, Forbidden, NotFound = import_common_modules()
-    client = bigquery.Client()
-    dataset_ref = f"{project}.{dataset}"
-    try:
-        tables = list(client.list_tables(dataset_ref))
-        return [table.table_id for table in tables], ""
-    except NotFound:
-        return [], f"Error: The dataset '{dataset_ref}' does not exist in BigQuery."
-    except Forbidden:
-        return [], f"Error: You do not have access to the dataset '{dataset_ref}'."
-    except Exception as e:
-        return [], f"Error: Failed to fetch tables from BigQuery: {e}"
+    def parse_schema(self, fields, prefix=""):
+        """
+        Parses the schema for a table and returns all the columns.
+        If a column is a struct then it recursively adds all nested columns.
+        """
+        schema_details = []
+
+        for field in fields:
+            if field.field_type == "RECORD":
+                # Recursively unnest fields within the struct
+                nested_fields = self.parse_schema(field.fields, prefix=f"{prefix}{field.name}.")
+                schema_details.extend(nested_fields)
+            else:
+                column = {"name": f"{prefix}{field.name}"}
+                if field.description:
+                    column["description"] = PreservedScalarString(field.description)
+                schema_details.append(column)
+
+        return schema_details
 
 
-def parse_schema(fields, prefix=""):
-    """
-    Parses the schema for a table and returns all the columns.
-    If a column is a struct then it recursively adds all nested columns.
-    """
-    schema_details = []
+    def fetch_table_columns(self, project, dataset, table_name) -> Tuple[List[str], str]:
+        """Fetch column names and descriptions from BigQuery."""
+        table_ref = f"{project}.{dataset}.{table_name}"
+        try:
+            table = self.get_client().get_table(table_ref)
+            columns = self.parse_schema(table.schema)
+            return columns, ""
+        except self.NotFound:
+            return None, f"Error: The table '{table_name}' does not exist in BigQuery."
+        except self.Forbidden:
+            return None, f"Error: You do not have access to the table '{table_name}'."
+        except Exception as e:
+            return None, f"Error: Failed to fetch table details from BigQuery: {e}"
 
-    for field in fields:
-        if field.field_type == "RECORD":
-            # Recursively unnest fields within the struct
-            nested_fields = parse_schema(field.fields, prefix=f"{prefix}{field.name}.")
-            schema_details.extend(nested_fields)
+
+    def check_project_exists(self, project) -> str:
+        """Checks whether the given project exists in BigQuery"""
+        try:
+            # Check if the project exists and is accessible
+            datasets = list(self.get_client().list_datasets(project=project))
+            if not datasets:
+                return f"Warning: The project '{project}' exists but contains no datasets."
+            else:
+                return "Exists"
+        except self.NotFound:
+            return f"Error: The project '{project}' does not exist."
+        except self.Forbidden:
+            return f"Error: You do not have access to the project '{project}'."
+        except Exception as e:
+            return f"Error: Failed to verify project '{project}': {e}"
+
+
+    def run_bq_query(self, project, query):
+        """Runs a query in bigquery"""
+        return self.get_client().query(query, project=project)
+
+
+    def delete_bq_table(self, table_id):
+        """Deletes a bq table"""
+        self.get_client().delete_table(table_id)
+
+
+    def get_bigquery_partition_expiration(self, table_id: str) -> int:
+        """Get the current partition expiration for a table in BigQuery."""
+        table = self.get_client().get_table(table_id)
+        if table.time_partitioning and table.time_partitioning.expiration_ms is not None:
+            return table.time_partitioning.expiration_ms // (1000 * 60 * 60 * 24)  # Convert ms to days
+        return -1  # Return -1 if no expiration is set
+
+
+    def update_bigquery_partition_expiration(self, table_id: str, expiration_days: int):
+        """Update the partition expiration for a table in BigQuery."""
+        table = self.get_client().get_table(table_id)
+        if table.time_partitioning:
+            table.time_partitioning.expiration_ms = expiration_days * 24 * 60 * 60 * 1000  # Convert days to ms
+            self.get_client().update_table(table, ["time_partitioning.expiration_ms"])
+            print(f"Updated partition expiration for {table_id} to {expiration_days} days")
         else:
-            column = {"name": f"{prefix}{field.name}"}
-            if field.description:
-                column["description"] = PreservedScalarString(field.description)
-            schema_details.append(column)
-
-    return schema_details
-
-
-def fetch_table_columns(project, dataset, table_name) -> Tuple[List[str], str]:
-    """Fetch column names and descriptions from BigQuery."""
-    bigquery, Forbidden, NotFound = import_common_modules()
-    client = bigquery.Client()
-    table_ref = f"{project}.{dataset}.{table_name}"
-    try:
-        table = client.get_table(table_ref)
-        columns = parse_schema(table.schema)
-        return columns, ""
-    except NotFound:
-        return None, f"Error: The table '{table_name}' does not exist in BigQuery."
-    except Forbidden:
-        return None, f"Error: You do not have access to the table '{table_name}'."
-    except Exception as e:
-        return None, f"Error: Failed to fetch table details from BigQuery: {e}"
-
-
-def check_project_exists(project) -> str:
-    """Checks whether the given project exists in BigQuery"""
-    bigquery, Forbidden, NotFound = import_common_modules()
-    client = bigquery.Client()
-    try:
-        # Check if the project exists and is accessible
-        datasets = list(client.list_datasets(project=project))
-        if not datasets:
-            return f"Warning: The project '{project}' exists but contains no datasets."
-        else:
-            return "Exists"
-    except NotFound:
-        return f"Error: The project '{project}' does not exist."
-    except Forbidden:
-        return f"Error: You do not have access to the project '{project}'."
-    except Exception as e:
-        return f"Error: Failed to verify project '{project}': {e}"
-
-
-def run_bq_query(project, query):
-    """Runs a query in bigquery"""
-    bigquery = import_module_once("google.cloud", "bigquery")
-    client = bigquery.Client(project=project)
-    return client.query(query)
-
-
-def delete_bq_table(table_id):
-    """Deletes a bq table"""
-    bigquery = import_module_once("google.cloud", "bigquery")
-    client = bigquery.Client()
-    client.delete_table(table_id)
-
-# Get the current partition expiration from BigQuery
-def get_bigquery_partition_expiration(table_id: str) -> int:
-    """Get the current partition expiration for a table in BigQuery."""
-    bigquery = import_module_once("google.cloud", "bigquery")
-    client = bigquery.Client()
-    table = client.get_table(table_id)
-    if table.time_partitioning and table.time_partitioning.expiration_ms is not None:
-        return table.time_partitioning.expiration_ms // (1000 * 60 * 60 * 24)  # Convert ms to days
-    return 0  # Return 0 if no expiration is set
-
-# Update partition expiration in BigQuery
-def update_bigquery_partition_expiration(table_id: str, expiration_days: int):
-    """Update the partition expiration for a table in BigQuery."""
-    bigquery = import_module_once("google.cloud", "bigquery")
-    client = bigquery.Client()
-    table = client.get_table(table_id)
-    if table.time_partitioning:
-        table.time_partitioning.expiration_ms = expiration_days * 24 * 60 * 60 * 1000  # Convert days to ms
-        client.update_table(table, ["time_partitioning.expiration_ms"])
-        print(f"Updated partition expiration for {table_id} to {expiration_days} days")
-    else:
-        print(f"Table {table_id} is not partitioned. Skipping update.")
+            print(f"Table {table_id} is not partitioned. Skipping update.")

--- a/dbtwiz/bigquery.py
+++ b/dbtwiz/bigquery.py
@@ -112,9 +112,12 @@ class BigQueryClient:
         """Runs a query in bigquery"""
         return self.get_client().query(query, project=project)
 
-    def delete_bq_table(self, table_id):
+    def delete_bq_table(self, table_id, project=None):
         """Deletes a bq table"""
-        self.get_client().delete_table(table_id)
+        if project:
+            self.get_client().delete_table(table_id, project=project)
+        else:
+            self.get_client().delete_table(table_id)
 
     def get_bigquery_partition_expiration(self, table_id: str) -> int:
         """Get the current partition expiration for a table in BigQuery."""

--- a/dbtwiz/bigquery.py
+++ b/dbtwiz/bigquery.py
@@ -4,6 +4,9 @@ from dbtwiz.logging import info
 from ruamel.yaml.scalarstring import PreservedScalarString
 
 
+MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24
+
+
 class BigQueryClient:
     """Class for BigQuery client"""
 
@@ -123,8 +126,8 @@ class BigQueryClient:
             table.time_partitioning
             and table.time_partitioning.expiration_ms is not None
         ):
-            return table.time_partitioning.expiration_ms // (
-                1000 * 60 * 60 * 24
+            return (
+                table.time_partitioning.expiration_ms // MILLISECONDS_PER_DAY
             )  # Convert ms to days
         return -1  # Return -1 if no expiration is set
 
@@ -137,10 +140,7 @@ class BigQueryClient:
                 type_=table.time_partitioning.type_,
                 field=table.time_partitioning.field,
                 expiration_ms=expiration_days
-                * 24
-                * 60
-                * 60
-                * 1000,  # Convert days to ms
+                * MILLISECONDS_PER_DAY,  # Convert days to ms
             )
             # Update the table with the new TimePartitioning configuration
             table.time_partitioning = updated_partitioning

--- a/dbtwiz/bigquery.py
+++ b/dbtwiz/bigquery.py
@@ -108,16 +108,13 @@ class BigQueryClient:
         except Exception as e:
             return f"Error: Failed to verify project '{project}': {e}"
 
-    def run_bq_query(self, project, query):
+    def run_query(self, project, query):
         """Runs a query in bigquery"""
         return self.get_client().query(query, project=project)
 
-    def delete_bq_table(self, table_id, project=None):
-        """Deletes a bq table"""
-        if project:
-            self.get_client().delete_table(table_id, project=project)
-        else:
-            self.get_client().delete_table(table_id)
+    def delete_table(self, table_id, project=None):
+        """Deletes a table from bigquery"""
+        self.get_client().delete_table(table_id, project=project)
 
     def get_bigquery_partition_expiration(self, table_id: str) -> int:
         """Get the current partition expiration for a table in BigQuery."""

--- a/dbtwiz/interact.py
+++ b/dbtwiz/interact.py
@@ -62,7 +62,7 @@ def select_from_list(
     """Select item from list"""
     from questionary import select  # Lazy import for improved performance
 
-    na_selection = {"name": "n/a", "description": "Not relevant for this model"}
+    na_selection = {"name": "n/a", "description": "Not relevant"}
     default = None
     if allow_none:
         items.insert(0, na_selection)
@@ -84,7 +84,7 @@ def multiselect_from_list(question, items, allow_none=False) -> List[str]:
     from questionary import checkbox  # Lazy import for improved performance
 
     validate = lambda sel: (len(sel) > 0) or "You must select at least one item"
-    na_selection = {"name": "n/a", "description": "Not relevant for this model"}
+    na_selection = {"name": "n/a", "description": "Not relevant"}
     default = None
     if allow_none:
         items.insert(0, na_selection)

--- a/dbtwiz/manifest.py
+++ b/dbtwiz/manifest.py
@@ -19,6 +19,15 @@ class Manifest:
     MODELS_INFO_PATH = project_dbtwiz_path("models")
 
 
+    def __init__(self, path: Path = MANIFEST_PATH):
+        # TODO: Check that the manifest file exists, and build it if not
+        with open(path, "r") as f:
+            manifest = json.load(f)
+            self.nodes = manifest["nodes"]
+            self.parent_map = manifest["parent_map"]
+            self.child_map = manifest["child_map"]
+
+
     @classmethod
     def models_cached(cls):
         """Get dictionary of models in local manifest, with JSON file for caching"""
@@ -62,9 +71,9 @@ class Manifest:
 
 
     @classmethod
-    def get_manifest(cls, type = 'dev'):
-        """Returns either local manifest or production manifest."""
-        manifest_path = Path(cls.PROD_MANIFEST_PATH if type == "prod" else cls.MANIFEST_PATH)
+    def get_manifest(cls, manifest_path):
+        """Reads and returns the manifest at the given path."""
+        manifest_path = Path(manifest_path)
     
         if not manifest_path.is_file():
             raise FileNotFoundError(f"The file at path '{manifest_path}' does not exist.")
@@ -108,15 +117,6 @@ class Manifest:
             # select contains special characters
             re.search(r"[:+*, ]", select) is not None
         )
-
-
-    def __init__(self, path: Path = MANIFEST_PATH):
-        # TODO: Check that the manifest file exists, and build it if not
-        with open(path, "r") as f:
-            manifest = json.load(f)
-            self.nodes = manifest["nodes"]
-            self.parent_map = manifest["parent_map"]
-            self.child_map = manifest["child_map"]
 
 
     def update_models_cache(self):

--- a/dbtwiz/manifest.py
+++ b/dbtwiz/manifest.py
@@ -1,6 +1,5 @@
 import functools
 import json
-import os
 import re
 from jinja2 import Template
 from pathlib import Path
@@ -40,7 +39,7 @@ class Manifest:
 
 
     @classmethod
-    def get_prod_manifest(cls):
+    def download_prod_manifest(cls):
         """Download latest production manifest"""
         info("Fetching production manifest")
         from google.cloud import storage #Only when used
@@ -59,7 +58,18 @@ class Manifest:
         if type in ('all', 'dev'):
             cls.rebuild_manifest()
         if type in ('all', 'prod'):
-            cls.get_prod_manifest()
+            cls.download_prod_manifest()
+
+
+    @classmethod
+    def get_manifest(cls, type = 'dev'):
+        """Returns either local manifest or production manifest."""
+        manifest_path = Path(cls.PROD_MANIFEST_PATH if type == "prod" else cls.MANIFEST_PATH)
+    
+        if not manifest_path.is_file():
+            raise FileNotFoundError(f"The file at path '{manifest_path}' does not exist.")
+        with manifest_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
 
 
     @classmethod


### PR DESCRIPTION
Added admin submodule for updating mismatched partition expiries.
It uses the production manifest to list tables with partition expiry defined, and compares the defined expiration with the bigquery table definition.

![image](https://github.com/user-attachments/assets/9ff74d2f-04eb-42e1-81df-6e85d233ed4e)

There is one optional argument, `--model-name` / `-m`, that can be provided as a filter:
![image](https://github.com/user-attachments/assets/d0a72d12-9987-4309-a3d6-50681698fb1b)