### PR TITLE
fix: fetch_tables_in_dataset returns names, not references

### DIFF
--- a/dbtwiz/admin/cleanup.py
+++ b/dbtwiz/admin/cleanup.py
@@ -33,15 +33,16 @@ def empty_development_dataset(force_delete: bool) -> None:
         if answer.lower() not in ["y", "yes"]:
             return
     for table in tables:
+        table_id = f"{project}.{dataset}.{table}"
         try:
-            client.delete_table(table, project)
+            client.delete_table(table_id)
             info(
-                f"Deleted {project}.{dataset}.{table}",
+                f"Deleted {table_id}",
                 style="red",
             )
         except Exception as e:
             error(
-                f"Failed to delete {project}.{dataset}.{table}: {e}"
+                f"Failed to delete {table_id}: {e}"
             )
 
 

--- a/dbtwiz/admin/cleanup.py
+++ b/dbtwiz/admin/cleanup.py
@@ -33,16 +33,15 @@ def empty_development_dataset(force_delete: bool) -> None:
         if answer.lower() not in ["y", "yes"]:
             return
     for table in tables:
-        table_type = table.table_type.lower()
         try:
             client.delete_table(table, project)
             info(
-                f"Deleted {table_type} {project}.{dataset}.{table.table_id}",
+                f"Deleted {project}.{dataset}.{table}",
                 style="red",
             )
         except Exception as e:
             error(
-                f"Failed to delete {table_type} {project}.{dataset}.{table.table_id}: {e}"
+                f"Failed to delete {project}.{dataset}.{table}: {e}"
             )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]


### PR DESCRIPTION
Fixed `empty_development_dataset` which was expecting table references, but now get table names from `fetch_tables_in_dataset`.

Bumped version to `0.2.4`.
