### PR TITLE
Fix: add support new dbt source structure

### DIFF
--- a/dbtwiz/dbt/project.py
+++ b/dbtwiz/dbt/project.py
@@ -181,7 +181,7 @@ def get_source_tables() -> Tuple[
 
     dbt_source_tables = {}
     dbt_sources = []
-    for yml_file in Path("sources").iterdir():
+    for yml_file in Path("sources").rglob("*"):
         if yml_file.suffix in {".yml", ".yaml"}:
             with open(yml_file, "r") as f:
                 content = safe_load(f)

--- a/dbtwiz/model/create.py
+++ b/dbtwiz/model/create.py
@@ -147,6 +147,9 @@ def select_group(context):
             valid_groups,
             must_exist=True,
             allow_blank=True,
+            validate=(
+                lambda str: (str is not None and str != "") or "You must select a group"
+            ),
         )
 
 

--- a/dbtwiz/source/create.py
+++ b/dbtwiz/source/create.py
@@ -157,7 +157,7 @@ def configure_missing_source(context):
             "tables": [],
             "file": Path("sources")
             / context["project_name"].replace("-", "_")
-            / f"{context['source_name']}__sources.yml",
+            / f"{context['source_name']}.yml",
         }
 
 

--- a/dbtwiz/source/create.py
+++ b/dbtwiz/source/create.py
@@ -155,7 +155,9 @@ def configure_missing_source(context):
             "project": context["project_name"],
             "dataset": context["dataset_name"],
             "tables": [],
-            "file": Path("sources") / f"{context['source_name']}__sources.yml",
+            "file": Path("sources")
+            / context["project_name"].replace("-", "_")
+            / f"{context['source_name']}__sources.yml",
         }
 
 


### PR DESCRIPTION
Add support new dbt source structure:
- recursive traversal of sources folder
- add projects to folder structure
- removed suffix `__sources`

In addition, enforced selection of group for `model create`, which could be skipped.