### PR TITLE
Fix: Correct model name for base path and pattern used to replace fqn with ref/source

### DIFF
--- a/dbtwiz/dbt/model.py
+++ b/dbtwiz/dbt/model.py
@@ -36,7 +36,7 @@ class ModelBasePath:
                 # Extract folder structure
                 layer_folder = parts[models_pos + 1]
                 self._domain = parts[models_pos + 2]
-                self._model_name = "_".join(parts[models_pos + 3 :])
+                self._model_name = path.name
 
                 # Set layer info
                 self._layer, self._layer_abbreviation = next(

--- a/dbtwiz/model/validate.py
+++ b/dbtwiz/model/validate.py
@@ -309,7 +309,7 @@ class SqlValidator:
             results.append("updated all references")
 
         if unresolved:
-            results.append("looks like a table, but found no model/source match - might be structs:\n  - " + "\n  - ".join(unresolved))
+            results.append("found potential table references that don't match known models/sources:\n  - " + "\n  - ".join(unresolved) + "\n-> this may be expected (e.g., struct fields)")
             status = False
 
         if new_sql == sql_content and not unresolved:

--- a/dbtwiz/model/validate.py
+++ b/dbtwiz/model/validate.py
@@ -262,8 +262,8 @@ class SqlValidator:
     def _replace_table_references(
         self, sql_content: str, lookup_dict: dict
     ) -> Tuple[str, List[str]]:
-        """Replace table references while handling all backtick cases."""
-        pattern = r"(`?[^`\s]+`?)\.(`?[^`\s]+`?)\.(`?[^`\s]+`?)"
+        """Replace table references while handling backticks."""
+        pattern = r"(`?[a-zA-Z0-9_-]+`?)\.(`?[a-zA-Z0-9_-]+`?)\.(`?[a-zA-Z0-9_-]+`?)"
         unresolved_tables = []
 
         new_sql = []
@@ -309,7 +309,7 @@ class SqlValidator:
             results.append("updated all references")
 
         if unresolved:
-            results.append("unresolved tables:\n  - " + "\n  - ".join(unresolved))
+            results.append("looks like a table, but found no model/source match - might be structs:\n  - " + "\n  - ".join(unresolved))
             status = False
 
         if new_sql == sql_content and not unresolved:

--- a/dbtwiz/model/validate.py
+++ b/dbtwiz/model/validate.py
@@ -309,7 +309,11 @@ class SqlValidator:
             results.append("updated all references")
 
         if unresolved:
-            results.append("found potential table references that don't match known models/sources:\n  - " + "\n  - ".join(unresolved) + "\n-> this may be expected (e.g., struct fields)")
+            results.append(
+                "found potential table references that don't match known models/sources:\n  - "
+                + "\n  - ".join(unresolved)
+                + "\n-> this may be expected (e.g., struct fields)"
+            )
             status = False
 
         if new_sql == sql_content and not unresolved:


### PR DESCRIPTION
Correct model name for base path and pattern used to replace fqn with ref/source