### PR TITLE
Fix: Corrected bq query when identifying orphaned models across projects

### DIFF
--- a/dbtwiz/admin/cleanup.py
+++ b/dbtwiz/admin/cleanup.py
@@ -65,9 +65,8 @@ def build_data_structure(manifest_models, client):
         info(f"Fetching datasets and tables for project {project}")
         query = f"""
             select table_schema, array_agg(table_name) as tables
-            from region-eu.INFORMATION_SCHEMA.TABLES
-            where table_catalog = '{project}'
-                and table_name not like '%__dbt_tmp_%'
+            from {project}.`region-eu`.INFORMATION_SCHEMA.TABLES
+            where table_name not like '%__dbt_tmp_%'
             group by table_schema
         """
         result = client.run_query(query).result()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-version = "0.2.5"
+version = "0.2.6"
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]


### PR DESCRIPTION
There was a bug in the bq query that fetches all tables from the information schema, as you can only query a single project at a time. The query is altered to specify the project for which information schema to use.