### PR TITLE
Fix: Corrected IAM policy setting for table migration

### DIFF
--- a/dbtwiz/gcp/bigquery.py
+++ b/dbtwiz/gcp/bigquery.py
@@ -509,7 +509,6 @@ class BigQueryClient:
 
             # Get table metadata and iam policy
             old_table = client.get_table(old_table_id)
-            old_iam_policy = client.get_iam_policy(old_table_id)
 
             old_table_name = old_table_id.split(".")[-1]
             backup_table_name = backup_table_id.split(".")[-1]
@@ -600,7 +599,7 @@ class BigQueryClient:
             )
 
             # Replicate grants from the old table/view to the view
-            client.set_iam_policy(view_id, old_iam_policy)
+            self._copy_iam_policy(source_table_id=old_table_id, target_table_id=view_id)
 
         except Exception as e:
             error(f"Error renaming table/view or creating view: {e}")


### PR DESCRIPTION
The IAM policy fix implemented in #54 should also have been added to the function `migrate_table`.

Example bug:
![image](https://github.com/user-attachments/assets/ca75ea0d-be62-479a-9614-a557614d745f)

After fix:
![image](https://github.com/user-attachments/assets/a860ff24-2ad9-435a-a032-c6b0c593bc5c)