### PR TITLE
Fix: use `shell=True` for `backfill` subprocess command to work in windows

### DIFF
--- a/dbtwiz/commands/backfill.py
+++ b/dbtwiz/commands/backfill.py
@@ -113,7 +113,7 @@ def run_command(args: list[str], verbose: bool = False, check: bool = True):
     """Run the given command in a subprocess"""
     if verbose:
         debug(f"Running command: {' '.join(args)}")
-    result = subprocess.run(args)
+    result = subprocess.run(args, shell=True)
     if check:
         result.check_returncode()
     return result


### PR DESCRIPTION
Use `shell=True` for `backfill` subprocess command to work in windows