### PR TITLE
Use string instead of list with subprocess.run when shell=True

### DIFF
--- a/dbtwiz/commands/backfill.py
+++ b/dbtwiz/commands/backfill.py
@@ -111,9 +111,10 @@ def job_spec_template():
 
 def run_command(args: list[str], verbose: bool = False, check: bool = True):
     """Run the given command in a subprocess"""
+    command = " ".join(args)
     if verbose:
-        debug(f"Running command: {' '.join(args)}")
-    result = subprocess.run(args, shell=True)
+        debug(f"Running command: {command}")
+    result = subprocess.run(command, shell=True)
     if check:
         result.check_returncode()
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-dynamic = ["version"]
+version = "0.2.10"
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-version = "0.2.9"
+version = "0.2.10"
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-version = "0.2.10"
+dynamic = ["version"]
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]


### PR DESCRIPTION
Passing a list as argument to `subprocess.run` when `shell=True` does not work in Linux, so pass a space-separated string instead.