### PR TITLE
Fix: added catch for failing queries to get project tables during cleanup

### DIFF
--- a/dbtwiz/admin/cleanup.py
+++ b/dbtwiz/admin/cleanup.py
@@ -60,18 +60,21 @@ def build_data_structure(manifest_models, client):
 
     # Add existing materializations in DWH by querying information schema
     for project in data.keys():
-        info(f"Fetching datasets and tables for project {project}")
-        query = f"""
-            select table_schema, array_agg(table_name) as tables
-            from {project}.`region-eu`.INFORMATION_SCHEMA.TABLES
-            where table_name not like '%__dbt_tmp_%'
-            group by table_schema
-        """
-        result = client.run_query(query).result()
-        for row in result:
-            dataset = row["table_schema"]
-            data[project][dataset] = data[project].get(dataset, dict(manifest=[]))
-            data[project][dataset]["bigquery"] = row["tables"]
+        try:
+            info(f"Fetching datasets and tables for project {project}")
+            query = f"""
+                select table_schema, array_agg(table_name) as tables
+                from {project}.`region-eu`.INFORMATION_SCHEMA.TABLES
+                where table_name not like '%__dbt_tmp_%'
+                group by table_schema
+            """
+            result = client.run_query(query).result()
+            for row in result:
+                dataset = row["table_schema"]
+                data[project][dataset] = data[project].get(dataset, dict(manifest=[]))
+                data[project][dataset]["bigquery"] = row["tables"]
+        except Exception:
+            error(f"Unable to fetch datasets for project {project}")
 
     return data
 


### PR DESCRIPTION
Added catch for failing queries to get project tables during cleanup.
If the service account doesn't have project level access to query `INFORMATION_SCHEMA.TABLES` then the query to fetch all tables will fail, and so will also the entire `dbtwiz admin orphaned` command.

It should instead just process for the projects it has access to, while informing the user about any projects it didn't have access to query.