### PR TITLE
Fix: corrected gcloud auth check

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ service_account_region = ""       # Region for where service account actions are
 
 # Config for user actions
 user_project = ""                 # Project name for where user queries are run
-user_auth_verified_domains = []   # Which domains to check when identifying whether user is already authenticated
 
 # Config for docker image used for backfill
 docker_image_url_dbt = ""         # Url for docker image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-version = "0.2.11"
+version = "0.2.12"
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]


### PR DESCRIPTION
Currently when running `backfill` and the user hasn't run `gcloud auth login`, the script will fail with this error message:
>Reauthentication required.
ERROR: (gcloud.auth.print-access-token) There was a problem refreshing your current auth tokens: Reauthentication failed. Reauthentication challenge failed due to API error: NO_AVAILABLE_CHALLENGES
Please run:
>$ gcloud auth login
>to obtain new credentials.
>If you have already logged in with a different account, run:
>to select an already authenticated account to use.

Originally, the script used `gcloud auth list` to identify authenticated users, but this didn't take into consideration whether the authentication token was still valid.

As a result, we now use `gcloud auth print-access-token` to ensure correct token status so that re-authentication is triggered when required.

The version is bumped to `0.2.12`.