### PR TITLE
Feature: add primary constraint check to model validation

### DIFF
--- a/dbtwiz/model/validate.py
+++ b/dbtwiz/model/validate.py
@@ -202,14 +202,13 @@ class YmlValidator:
 
         # Check model-level primary key
         model_level_pk = any(
-            c.get('type') == 'primary_key'
-            for c in model_def.get('constraints', [])
+            c.get("type") == "primary_key" for c in model_def.get("constraints", [])
         )
 
         column_level_pk_columns = [
-            col['name']
-            for col in model_def.get('columns', [])
-            if any(c.get('type') == 'primary_key' for c in col.get('constraints', []))
+            col["name"]
+            for col in model_def.get("columns", [])
+            if any(c.get("type") == "primary_key" for c in col.get("constraints", []))
         ]
         column_level_pk = len(column_level_pk_columns) > 0
 
@@ -218,7 +217,7 @@ class YmlValidator:
         elif model_level_pk and column_level_pk:
             return "primary key constraint is defined at both model and column levels"
         elif column_level_pk and len(column_level_pk_columns) > 1:
-            return f"primary key constraint is defined for multiple columns - it must be changed to a model level constraint"
+            return "primary key constraint is defined for multiple columns - it must be changed to a model level constraint"
         return None
 
     def validate_yml_definition(self) -> Tuple[bool, str]:
@@ -242,9 +241,11 @@ class YmlValidator:
             model_def=yml_content.get("models")[0]
         )
 
-        if (pk_constraint_error := self.validate_yml_primary_key_constraint(
-            model_def=yml_content.get("models")[0])
-            ) is not None:
+        if (
+            pk_constraint_error := self.validate_yml_primary_key_constraint(
+                model_def=yml_content.get("models")[0]
+            )
+        ) is not None:
             validation_errors.append(pk_constraint_error)
 
         if validation_errors:

--- a/dbtwiz/model/validate.py
+++ b/dbtwiz/model/validate.py
@@ -196,6 +196,31 @@ class YmlValidator:
 
         return validation_errors
 
+    def validate_yml_primary_key_constraint(self, model_def: dict) -> bool:
+        """Validates that a primary key constraint is defined for the model."""
+        column_level_pk = False
+
+        # Check model-level primary key
+        model_level_pk = any(
+            c.get('type') == 'primary_key'
+            for c in model_def.get('constraints', [])
+        )
+
+        column_level_pk_columns = [
+            col['name']
+            for col in model_def.get('columns', [])
+            if any(c.get('type') == 'primary_key' for c in col.get('constraints', []))
+        ]
+        column_level_pk = len(column_level_pk_columns) > 0
+
+        if not model_level_pk and not column_level_pk:
+            return "primary key constraint is missing"
+        elif model_level_pk and column_level_pk:
+            return "primary key constraint is defined at both model and column levels"
+        elif column_level_pk and len(column_level_pk_columns) > 1:
+            return f"primary key constraint is defined for multiple columns - it must be changed to a model level constraint"
+        return None
+
     def validate_yml_definition(self) -> Tuple[bool, str]:
         """Validates YML definition (currently only the model name)."""
         yml_path = self.model_base.path.with_suffix(".yml")
@@ -216,6 +241,11 @@ class YmlValidator:
         validation_errors = self._validate_model_name(
             model_def=yml_content.get("models")[0]
         )
+
+        if (pk_constraint_error := self.validate_yml_primary_key_constraint(
+            model_def=yml_content.get("models")[0])
+            ) is not None:
+            validation_errors.append(pk_constraint_error)
 
         if validation_errors:
             error_msg = "failed\n" + "\n".join(f"• {e}" for e in validation_errors)

--- a/dbtwiz/model/validate.py
+++ b/dbtwiz/model/validate.py
@@ -200,7 +200,6 @@ class YmlValidator:
         """Validates that a primary key constraint is defined for the model."""
         column_level_pk = False
 
-        # Check model-level primary key
         model_level_pk = any(
             c.get("type") == "primary_key" for c in model_def.get("constraints", [])
         )


### PR DESCRIPTION
It is best practice to always define a primary key constraint for all models. This isn't currently enforced by BigQuery, but is very informative and can also be used by BigQuery for query optimization.

Due to these reasons, another check is added to the model yaml validation to ensure that a primary key constraint is added. In addition, it verifies that it is added only at either the model or column level, and only for a single column if defined at the column level.