### PR TITLE
Fix: removed setting of quota project due to lack of serviceusage.services.use for certain users

### DIFF
--- a/dbtwiz/gcp/auth.py
+++ b/dbtwiz/gcp/auth.py
@@ -17,14 +17,9 @@ def check_gcloud_installed():
 
 
 def app_default_auth_login():
-    """Triggers application default authorization and sets quota project."""
+    """Triggers application default authorization."""
     if confirm("Do you wish to reauthenticate now?"):
         subprocess.run("gcloud auth application-default login", shell=True)
-        if project_config().user_project:
-            subprocess.run(
-                f"gcloud auth application-default set-quota-project {project_config().user_project}",
-                shell=True,
-            )
 
 
 def ensure_app_default_auth() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-version = "0.2.13"
+version = "0.2.14"
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]


### PR DESCRIPTION
Removed setting of quota project due to lack of serviceusage.services.use for certain users

>Run $ gcloud auth application-default set-quota-project to add a quota project.
>ERROR: (gcloud.auth.application-default.set-quota-project) Cannot add the project "amedia-analytics-eu" to application default credentials (ADC) as a quota project because the account in ADC does not have the "serviceusage.services.use" permission on this project.