### PR TITLE
Fix: correct auth issue for backfill that happens in codespaces

### DIFF
--- a/dbtwiz/gcp/auth.py
+++ b/dbtwiz/gcp/auth.py
@@ -48,7 +48,8 @@ def ensure_app_default_auth() -> None:
 
 
 def ensure_gcloud_auth() -> None:
-    """Ensures gcloud authorization is active."""
+    """Ensures gcloud authorization is active.
+    TODO: This works locally, but not in codespaces"""
     if not check_gcloud_installed():
         fatal(
             "Error checking gcloud authentication. Ensure gcloud is installed correctly."

--- a/dbtwiz/gcp/auth.py
+++ b/dbtwiz/gcp/auth.py
@@ -48,8 +48,7 @@ def ensure_app_default_auth() -> None:
 
 
 def ensure_gcloud_auth() -> None:
-    """Ensures gcloud authorization is active.
-    TODO: This works locally, but not in codespaces"""
+    """Ensures gcloud authorization is active."""
     if not check_gcloud_installed():
         fatal(
             "Error checking gcloud authentication. Ensure gcloud is installed correctly."

--- a/dbtwiz/gcp/auth.py
+++ b/dbtwiz/gcp/auth.py
@@ -67,6 +67,7 @@ def ensure_gcloud_auth() -> None:
     if (
         "Reauthentication required" in result.stderr
         or "There was a problem refreshing your current auth tokens" in result.stderr
+        or "You do not currently have an active account selected" in result.stderr
     ):
         if confirm("Do you wish to reauthenticate now?"):
             subprocess.run("gcloud auth login", check=True, shell=True)


### PR DESCRIPTION
The check that identifies whether `gcloud auth login` is required for `backfill` works locally, but not in a codespace.

The cause seems to be that the error message returned is: `You do not currently have an active account selected`
And this isn't one of the error messages that are checked by the code.