### PR TITLE
feat: pass is_backfill dbt variable during backfill runs

### DIFF
--- a/dbtwiz/admin/backfill.py
+++ b/dbtwiz/admin/backfill.py
@@ -95,6 +95,7 @@ def job_spec_template():
                 - --batch-size
                 - "{{ batch_size }}"
                 - --use-task-index
+                - --backfill
                 {% if full_refresh %}
                 - --full-refresh
                 {%- endif %}

--- a/dbtwiz/commands/__init__.py
+++ b/dbtwiz/commands/__init__.py
@@ -123,6 +123,14 @@ file `.dbtwiz/last_select.json` in the current project.
 Pass this option to rebuild the same models that you most recently built.""",
         ),
     ] = False,
+    backfill: Annotated[
+        bool,
+        typer.Option(
+            "--backfill",
+            help="""Sets the dbt variable `is_backfill` to true.
+This is automatically set when running via `dbtwiz admin backfill`.""",
+        ),
+    ] = False,
 ) -> None:
     """Build one or more dbt models with interactive selection or exact names."""
     # Validate
@@ -152,6 +160,7 @@ Pass this option to rebuild the same models that you most recently built.""",
         downstream=downstream,
         work=work,
         repeat_last=repeat_last,
+        backfill=backfill,
     )
 
 

--- a/dbtwiz/commands/build.py
+++ b/dbtwiz/commands/build.py
@@ -38,6 +38,7 @@ def build(
     downstream: bool,
     work: bool,
     repeat_last: bool,
+    backfill: bool = False,
 ) -> None:
     """Builds the given models."""
     if target == "dev":
@@ -69,7 +70,7 @@ def build(
     commands = ["build"]
     args = {
         "target": target,
-        "vars": f'{{data_interval_start: "{start_date}", data_interval_end: "{end_date}"}}',
+        "vars": f'{{data_interval_start: "{start_date}", data_interval_end: "{end_date}", is_backfill: {"true" if backfill else "false"}}}',
         "exclude": "tag:no_backfill",
     }
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -66,3 +66,8 @@ When you build with dbtwiz, it will store a list of selected models in the
 file `.dbtwiz/last_select.json` in the current project.
 
 Pass this option to rebuild the same models that you most recently built.
+
+### `--backfill`
+
+Sets the dbt variable `is_backfill` to true.
+This is automatically set when running via `dbtwiz admin backfill`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-version = "0.2.48"
+version = "0.2.49"
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]


### PR DESCRIPTION
## Summary
- Adds `--backfill` flag to the `dbtwiz build` command, which sets the dbt variable `is_backfill` to `true`
- The Cloud Run job spec for `dbtwiz admin backfill` automatically includes `--backfill`, so all backfill jobs set this variable
- dbt models can use `var('is_backfill', false)` to implement backfill-specific logic