### PR TITLE
Fix: restore interactive yml creation in model validate

### DIFF
--- a/dbtwiz/model/validate.py
+++ b/dbtwiz/model/validate.py
@@ -35,31 +35,26 @@ class YmlValidator:
 
     def validate_yml_exists(self) -> Tuple[bool, str]:
         """Validates that the yml exists, or triggers yml creation if not."""
+        import subprocess
+
         yml_path = self.model_base.path.with_suffix(".yml")
         if not yml_path.exists():
             warn(
                 f"{self.model_base.model_name}: yml file missing - [italic]creating[/italic]"
             )
-            import subprocess
-
-            try:
-                subprocess.run(
-                    [
-                        "dbtwiz",
-                        "model",
-                        "create",
-                        "-l",
-                        self.model_base.layer,
-                        "-d",
-                        self.model_base.domain,
-                        "-n",
-                        self.model_base.identifier,
-                    ],
-                    check=True,
-                    capture_output=True,
-                )
-            except subprocess.CalledProcessError:
-                pass  # Continue even if creation fails
+            subprocess.run(
+                [
+                    "dbtwiz",
+                    "model",
+                    "create",
+                    "-l",
+                    self.model_base.layer,
+                    "-d",
+                    self.model_base.domain,
+                    "-n",
+                    self.model_base.identifier,
+                ],
+            )
             if yml_path.exists():
                 return True, f"yml file created successfully: {yml_path.name}"
             if not yml_path.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-version = "0.2.49"
+version = "0.2.50"
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]


### PR DESCRIPTION
## What

`dbtwiz model validate` is supposed to automatically create a missing yml file by launching the interactive `model create` flow. This was broken by the refactor in #85, which replaced `os.system()` with `subprocess.run(..., capture_output=True)`.

## Why it broke

`capture_output=True` redirects stdin away from the terminal, so all interactive prompts in `model create` (source selection, confirmation, etc.) fail silently. The subprocess exits without creating the yml file, and validation crashes with a `FileNotFoundError` when it tries to open it.

## Fix

Replace `os.system()` / `subprocess.run(..., capture_output=True)` with `subprocess.run()` using a proper argument list and no output capture. This lets the subprocess inherit the parent's stdin/stdout/stderr, restoring the original interactive behaviour while being more robust than `os.system()` (no shell quoting concerns, cross-platform argument handling).