### PR TITLE
feat: add --retry and --dry-run to backfill command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also run `dbtwiz --help`/`dbtwiz -h`, which will list the commands with 
 - [`test`](docs/test.md) - Test dbt models with optional date specification.
 - [`manifest`](docs/manifest.md) - Update dbt manifests for fast lookup and caching.
 - `admin` - Production backfilling and administrative tasks
-  - [`backfill`](docs/admin_backfill.md) - Backfill date-partitioned models in production for a specified date range. Spawns Cloud Run jobs to process multiple dates in parallel with configurable batch sizes.
+  - [`backfill`](docs/admin_backfill.md) - Backfill date-partitioned models in production for a specified date range. Spawns Cloud Run jobs to process multiple dates in parallel with configurable batch sizes. Use --retry to re-run only the failed tasks from the most recent execution.
   - [`cleandev`](docs/admin_cleandev.md) - Delete all materializations in the dbt development dataset
   - [`orphaned`](docs/admin_orphaned.md) - List or delete orphaned materializations in the data warehouse
   - [`partition-expiry`](docs/admin_partition_expiry.md) - Checks for mismatched partition expiry and allows updating to correct.

--- a/dbtwiz/admin/__init__.py
+++ b/dbtwiz/admin/__init__.py
@@ -17,6 +17,48 @@ app = typer.Typer(help="Administrative commands for dbt project management")
 __all__ = ["app", "empty_development_dataset"]
 
 
+def _validate_backfill_args(
+    select: str,
+    date_first: str | None,
+    date_last: str | None,
+    full_refresh: bool,
+    retry: bool,
+) -> tuple[datetime.date | None, datetime.date | None]:
+    """Validate backfill arguments and return (first_date, last_date)."""
+    from ..utils.logger import warn
+
+    if retry:
+        if full_refresh:
+            raise InvalidArgumentsError(
+                "--retry cannot be combined with --full-refresh."
+            )
+        if date_first is not None or date_last is not None:
+            warn("Date arguments are ignored when --retry is set.")
+        return None, None
+
+    if date_first is None:
+        raise InvalidArgumentsError(
+            "date_first is required (omit it only when using --retry)."
+        )
+    try:
+        first_date = datetime.date.fromisoformat(date_first)
+        last_date = datetime.date.fromisoformat(date_last) if date_last else first_date
+    except ValueError:
+        raise InvalidArgumentsError("Dates must be on the YYYY-mm-dd format.")
+    if last_date < first_date:
+        raise InvalidArgumentsError("Last date must be on or after first date.")
+    if full_refresh:
+        if "+" in select:
+            raise InvalidArgumentsError(
+                "Full refresh is only supported on single models."
+            )
+        if last_date != first_date:
+            raise InvalidArgumentsError(
+                "Full refresh in only supported on single day runs."
+            )
+    return first_date, last_date
+
+
 @app.command()
 @examples(
     """Example of the basic use-case:
@@ -36,8 +78,15 @@ be opened in your browser so you can track progress."""
 def backfill(
     select: Annotated[str, typer.Argument(help="Model selector passed to dbt")],
     date_first: Annotated[
-        str, typer.Argument(help="Start of backfill period [YYYY-mm-dd]")
-    ],
+        str,
+        typer.Argument(
+            help=(
+                "Start of backfill period [YYYY-mm-dd]. "
+                "Optional (and ignored) when --retry is set."
+            ),
+            metavar="TEXT",
+        ),
+    ] = None,
     date_last: Annotated[
         str,
         typer.Argument(
@@ -50,9 +99,24 @@ def backfill(
         typer.Option(
             "--batch-size",
             "-b",
-            help=("Number of dates to include in each batch."),
+            help=(
+                "Number of dates to include in each batch. "
+                "When used with --retry, subdivides each failed range to this size; "
+                "if omitted on retry, the failed ranges are retried as-is."
+            ),
         ),
-    ] = project_config().backfill_default_batch_size or 30,
+    ] = None,
+    retry: Annotated[
+        bool,
+        typer.Option(
+            "--retry",
+            help=(
+                "Retry only the failed tasks from the most recent execution of this backfill "
+                "job (looked up by selector). When set, date arguments are ignored. "
+                "Pass --batch-size to subdivide failed ranges before retrying."
+            ),
+        ),
+    ] = False,
     full_refresh: Annotated[
         bool,
         typer.Option(
@@ -90,28 +154,30 @@ def backfill(
         bool,
         typer.Option("--verbose", "-v", help="Output more info about what is going on"),
     ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help=(
+                "Print the tasks that would be submitted without actually running the job. "
+                "Works with and without --retry."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Backfill date-partitioned models in production for a specified date range.
 
     Spawns Cloud Run jobs to process multiple dates in parallel with configurable batch sizes.
+    Use --retry to re-run only the failed tasks from the most recent execution.
     """
-    # Validate
-    try:
-        first_date = datetime.date.fromisoformat(date_first)
-        last_date = datetime.date.fromisoformat(date_last) if date_last else first_date
-    except ValueError:
-        raise InvalidArgumentsError("Dates must be on the YYYY-mm-dd format.")
-    if last_date < first_date:
-        raise InvalidArgumentsError("Last date must be on or after first date.")
-    if full_refresh:
-        if "+" in select:
-            raise InvalidArgumentsError(
-                "Full refresh is only supported on single models."
-            )
-        if last_date != first_date:
-            raise InvalidArgumentsError(
-                "Full refresh in only supported on single day runs."
-            )
+    batch_size_overridden = batch_size is not None
+    if batch_size is None:
+        batch_size = project_config().backfill_default_batch_size or 30
+
+    first_date, last_date = _validate_backfill_args(
+        select, date_first, date_last, full_refresh, retry
+    )
+
     from .backfill import backfill as command_backfill
 
     # Dispatch
@@ -124,6 +190,9 @@ def backfill(
         parallelism=parallelism,
         status=status,
         verbose=verbose,
+        retry=retry,
+        dry_run=dry_run,
+        batch_size_overridden=batch_size_overridden,
     )
 
 

--- a/dbtwiz/admin/backfill.py
+++ b/dbtwiz/admin/backfill.py
@@ -3,8 +3,7 @@ import shutil
 import subprocess
 import time
 import webbrowser
-from datetime import date
-from math import ceil
+from datetime import date, timedelta
 from textwrap import dedent
 
 from jinja2 import Template
@@ -18,6 +17,36 @@ from ..utils.logger import debug, fatal, info, warn
 
 MAX_CONCURRENT_TASKS = 8
 YAML_FILE = project_dbtwiz_path("backfill-cloudrun.yaml")
+
+
+def chunk_date_range(
+    first: date, last: date, batch_size: int
+) -> list[tuple[date, date]]:
+    """Split [first, last] (inclusive) into contiguous chunks of at most batch_size days."""
+    ranges: list[tuple[date, date]] = []
+    cursor = first
+    while cursor <= last:
+        chunk_end = min(last, cursor + timedelta(days=batch_size - 1))
+        ranges.append((cursor, chunk_end))
+        cursor = chunk_end + timedelta(days=1)
+    return ranges
+
+
+def encode_task_ranges(ranges: list[tuple[date, date]]) -> str:
+    """Encode date-pair ranges into the --task-ranges arg format."""
+    return ",".join(f"{s.isoformat()}:{e.isoformat()}" for s, e in ranges)
+
+
+def decode_task_ranges(encoded: str) -> list[tuple[date, date]]:
+    """Inverse of encode_task_ranges."""
+    out: list[tuple[date, date]] = []
+    for piece in encoded.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        s, e = piece.split(":")
+        out.append((date.fromisoformat(s.strip()), date.fromisoformat(e.strip())))
+    return out
 
 
 def halve_str(word: str) -> str:
@@ -88,12 +117,8 @@ def job_spec_template():
                 - "prod"
                 - --select
                 - "{{ selector }}"
-                - --start-date
-                - "{{ start_date }}"
-                - --end-date
-                - "{{ end_date }}"
-                - --batch-size
-                - "{{ batch_size }}"
+                - --task-ranges
+                - "{{ task_ranges }}"
                 - --use-task-index
                 - --backfill
                 {% if full_refresh %}
@@ -112,19 +137,20 @@ def job_spec_template():
 
 def generate_job_spec(
     selector: str,
-    date_first: date,
-    date_last: date,
+    ranges: list[tuple[date, date]],
     full_refresh: bool,
     parallelism: int,
-    batch_size: int,
 ) -> str:
-    """Generate job specification YAML file"""
-    number_of_days = (date_last - date_first).days + 1
-    task_count = ceil(number_of_days / batch_size)
+    """Generate job specification YAML file from an explicit list of per-task date ranges."""
+    task_count = len(ranges)
+    if task_count == 0:
+        fatal("No date ranges to run.")
     parallelism = min(task_count, parallelism)
     job_name = backfill_job_name(selector)
     if full_refresh:
-        assert number_of_days == 1
+        assert task_count == 1
+        first, last = ranges[0]
+        assert first == last
         assert "+" not in selector
     job_spec_yaml = job_spec_template().render(
         job_name=job_name,
@@ -132,9 +158,7 @@ def generate_job_spec(
         task_count=task_count,
         image=project_config().docker_image_url_dbt,
         selector=selector,
-        start_date=date_first.strftime("%Y-%m-%d"),
-        end_date=date_last.strftime("%Y-%m-%d"),
-        batch_size=batch_size,
+        task_ranges=encode_task_ranges(ranges),
         full_refresh=full_refresh,
         service_account=project_config().service_account_identifier,
         service_account_region=project_config().service_account_region,
@@ -174,49 +198,150 @@ def run_command(args: list[str], verbose: bool = False, check: bool = True):
     return result
 
 
-def backfill(
-    selector: str,
-    first_date: date,
-    last_date: date,
-    full_refresh: bool,
-    parallelism: int,
-    status: bool,
-    verbose: bool,
-    batch_size: int,
-):
-    """Runs backfill for the given selector and date interval."""
-    ensure_auth()
+def _cloud_run_session():
+    """Return an AuthorizedSession for the Cloud Run Admin v2 REST API."""
+    from google.auth import default
+    from google.auth.transport.requests import AuthorizedSession
 
-    # Verify valid selector
-    selected_models = get_selected_models(select=selector)
+    credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    return AuthorizedSession(credentials)
 
-    if len(selected_models) == 0:
-        fatal(
-            f"No models selected by statement '{selector}'. Please check the model name(s)."
-        )
-    else:
-        materialized_counts = {}
-        for item in selected_models:
-            key = item["config"]["materialized"]
-            materialized_counts[key] = materialized_counts.get(key, 0) + 1
 
-        if materialized_counts.get("incremental", 0) == 0:
-            warn(
-                "No incremental models were selected, so provided dates will be ignored."
-            )
-            if not confirm("Would you still like to run?"):
-                return
-            first_date = last_date = date.today()
-
-    job_name = generate_job_spec(
-        selector=selector,
-        date_first=first_date,
-        date_last=last_date,
-        full_refresh=full_refresh,
-        parallelism=parallelism,
-        batch_size=batch_size,
+def _cloud_run_v2_base_url() -> str:
+    region = project_config().service_account_region
+    project = project_config().service_account_project
+    return (
+        f"https://{region}-run.googleapis.com/v2/projects/{project}/locations/{region}"
     )
 
+
+def fetch_latest_execution(job_name: str, verbose: bool = False) -> dict:
+    """Return the most recent Cloud Run v2 execution resource for the given job."""
+    session = _cloud_run_session()
+    list_url = f"{_cloud_run_v2_base_url()}/jobs/{job_name}/executions"
+    if verbose:
+        debug(f"GET {list_url}")
+    resp = session.get(list_url, params={"pageSize": 1})
+    if resp.status_code == 404:
+        fatal(
+            f"No Cloud Run job named '{job_name}' found. "
+            "Has this backfill ever been run?"
+        )
+    if not resp.ok:
+        fatal(
+            f"Failed to list executions for '{job_name}': {resp.status_code} {resp.text}"
+        )
+    executions = resp.json().get("executions") or []
+    if not executions:
+        fatal(
+            f"No previous executions found for job '{job_name}'. "
+            "Run a fresh backfill before using --retry."
+        )
+    # The list endpoint already returns full execution resources, no need to re-fetch.
+    return executions[0]
+
+
+def extract_container_args(execution: dict) -> list[str]:
+    """Extract the container args list from a Cloud Run v2 execution resource."""
+    try:
+        containers = execution["template"]["containers"]
+        return list(containers[0].get("args", []))
+    except (KeyError, IndexError) as exc:
+        fatal(f"Could not read container args from previous execution: {exc}")
+
+
+def get_arg_value(args: list[str], flag: str) -> str | None:
+    """Return the value following the given flag in a list of CLI args, or None."""
+    try:
+        idx = args.index(flag)
+    except ValueError:
+        return None
+    if idx + 1 >= len(args):
+        return None
+    return args[idx + 1]
+
+
+def recover_previous_ranges(args: list[str]) -> list[tuple[date, date]]:
+    """Recover the per-task date ranges from a previous execution's container args.
+
+    Supports both new-style (--task-ranges) and old-style
+    (--start-date/--end-date/--batch-size) executions.
+    """
+    encoded = get_arg_value(args, "--task-ranges")
+    if encoded:
+        return decode_task_ranges(encoded)
+
+    start_str = get_arg_value(args, "--start-date")
+    end_str = get_arg_value(args, "--end-date")
+    bs_str = get_arg_value(args, "--batch-size")
+    if not (start_str and end_str and bs_str):
+        fatal(
+            "Could not recover date ranges from previous execution: "
+            "missing --task-ranges and --start-date/--end-date/--batch-size."
+        )
+    return chunk_date_range(
+        date.fromisoformat(start_str), date.fromisoformat(end_str), int(bs_str)
+    )
+
+
+def extract_failed_task_indices(execution: dict, verbose: bool = False) -> list[int]:
+    """Return the sorted list of zero-based task indices that did not succeed.
+
+    Uses the Cloud Run v2 tasks endpoint to enumerate per-task state.
+    """
+    task_count = execution.get("taskCount")
+    if task_count is None:
+        fatal("Could not determine task count from previous execution.")
+    succeeded = execution.get("succeededCount", 0) or 0
+    if succeeded == task_count:
+        return []
+
+    # Derive the execution-relative path from its fully-qualified resource name:
+    #   projects/.../locations/.../jobs/.../executions/<exec>
+    execution_path = execution["name"]
+    session = _cloud_run_session()
+    tasks_url = f"https://{project_config().service_account_region}-run.googleapis.com/v2/{execution_path}/tasks"
+    if verbose:
+        debug(f"GET {tasks_url}")
+
+    failed: list[int] = []
+    next_page_token: str | None = None
+    while True:
+        params: dict[str, str] = {"pageSize": "500"}
+        if next_page_token:
+            params["pageToken"] = next_page_token
+        resp = session.get(tasks_url, params=params)
+        if not resp.ok:
+            fatal(f"Failed to list tasks for execution: {resp.status_code} {resp.text}")
+        payload = resp.json()
+        for task in payload.get("tasks") or []:
+            # Protobuf JSON omits zero-valued integers, so a missing 'index' means 0.
+            index = int(task.get("index", 0))
+            conditions = task.get("conditions") or []
+            completed_ok = any(
+                c.get("type") == "Completed" and c.get("state") == "CONDITION_SUCCEEDED"
+                for c in conditions
+            )
+            if not completed_ok:
+                failed.append(index)
+        next_page_token = payload.get("nextPageToken")
+        if not next_page_token:
+            break
+    return sorted(failed)
+
+
+def subdivide_ranges(
+    ranges: list[tuple[date, date]], batch_size: int
+) -> list[tuple[date, date]]:
+    """Re-chunk each range so no chunk exceeds batch_size days."""
+    new_ranges: list[tuple[date, date]] = []
+    for start, end in ranges:
+        new_ranges.extend(chunk_date_range(start, end, batch_size))
+    return new_ranges
+
+
+def submit_job(job_name: str, verbose: bool, status: bool) -> None:
+    """Replace and execute the Cloud Run job from the rendered YAML."""
     ensure_auth(check_app_default_auth=False, check_gcloud_auth=True)
     service_account_project = project_config().service_account_project
     service_account_region = project_config().service_account_region
@@ -256,3 +381,128 @@ def backfill(
     if status:
         webbrowser.open(job_url)
         time.sleep(0.5)
+
+
+def _print_dry_run_summary(ranges: list[tuple[date, date]], job_name: str) -> None:
+    info(f"Dry run — job '{job_name}' would submit {len(ranges)} task(s):")
+    for i, (s, e) in enumerate(ranges):
+        days = (e - s).days + 1
+        info(f"  task {i:>3}: {s} → {e}  ({days} day{'s' if days > 1 else ''})")
+
+
+def _backfill_retry(
+    selector: str,
+    parallelism: int,
+    status: bool,
+    verbose: bool,
+    batch_size: int,
+    dry_run: bool,
+    batch_size_overridden: bool,
+) -> None:
+    """Retry failed tasks from the most recent execution."""
+    job_name = backfill_job_name(selector)
+    info(f"Looking up most recent execution of job '{job_name}'.")
+    execution = fetch_latest_execution(job_name, verbose=verbose)
+
+    if not execution.get("completionTime"):
+        fatal(
+            "Previous execution has not completed yet. "
+            "Wait for it to finish before retrying."
+        )
+
+    previous_args = extract_container_args(execution)
+    previous_ranges = recover_previous_ranges(previous_args)
+    failed_indices = extract_failed_task_indices(execution, verbose=verbose)
+
+    if not failed_indices:
+        info("No failed tasks in the most recent execution; nothing to retry.")
+        return
+
+    failed_ranges = [previous_ranges[i] for i in failed_indices]
+    info(
+        f"Found {len(failed_ranges)} failed task(s) out of "
+        f"{len(previous_ranges)} in the previous execution."
+    )
+
+    if batch_size_overridden:
+        ranges = subdivide_ranges(failed_ranges, batch_size)
+        info(
+            f"Subdividing failed ranges with batch size {batch_size}: "
+            f"{len(failed_ranges)} → {len(ranges)} tasks."
+        )
+    else:
+        ranges = failed_ranges
+
+    if dry_run:
+        _print_dry_run_summary(ranges, job_name)
+        return
+
+    previous_full_refresh = "--full-refresh" in previous_args
+    generate_job_spec(
+        selector=selector,
+        ranges=ranges,
+        full_refresh=previous_full_refresh,
+        parallelism=parallelism,
+    )
+    submit_job(job_name, verbose=verbose, status=status)
+
+
+def backfill(
+    selector: str,
+    first_date: date | None,
+    last_date: date | None,
+    full_refresh: bool,
+    parallelism: int,
+    status: bool,
+    verbose: bool,
+    batch_size: int,
+    retry: bool = False,
+    dry_run: bool = False,
+    batch_size_overridden: bool = False,
+):
+    """Runs backfill for the given selector and date interval, or retries failed tasks."""
+    ensure_auth()
+
+    if retry:
+        _backfill_retry(
+            selector=selector,
+            parallelism=parallelism,
+            status=status,
+            verbose=verbose,
+            batch_size=batch_size,
+            dry_run=dry_run,
+            batch_size_overridden=batch_size_overridden,
+        )
+        return
+
+    selected_models = get_selected_models(select=selector)
+    if len(selected_models) == 0:
+        fatal(
+            f"No models selected by statement '{selector}'. Please check the model name(s)."
+        )
+
+    materialized_counts = {}
+    for item in selected_models:
+        key = item["config"]["materialized"]
+        materialized_counts[key] = materialized_counts.get(key, 0) + 1
+
+    if materialized_counts.get("incremental", 0) == 0:
+        warn("No incremental models were selected, so provided dates will be ignored.")
+        if not confirm("Would you still like to run?"):
+            return
+        first_date = last_date = date.today()
+
+    ranges = chunk_date_range(first_date, last_date, batch_size)
+    job_name = backfill_job_name(selector)
+
+    if dry_run:
+        _print_dry_run_summary(ranges, job_name)
+        return
+
+    job_name = generate_job_spec(
+        selector=selector,
+        ranges=ranges,
+        full_refresh=full_refresh,
+        parallelism=parallelism,
+    )
+    submit_job(job_name, verbose=verbose, status=status)

--- a/dbtwiz/commands/__init__.py
+++ b/dbtwiz/commands/__init__.py
@@ -131,6 +131,17 @@ Pass this option to rebuild the same models that you most recently built.""",
 This is automatically set when running via `dbtwiz admin backfill`.""",
         ),
     ] = False,
+    task_ranges: Annotated[
+        str,
+        typer.Option(
+            "--task-ranges",
+            help="""Comma-separated list of date ranges, one per task, on the form
+`YYYY-MM-DD:YYYY-MM-DD,YYYY-MM-DD:YYYY-MM-DD,...`. When used together with
+`--use-task-index`, the task picks the range at index `CLOUD_RUN_TASK_INDEX`
+and ignores `--start-date`, `--end-date`, and `--batch-size`. Set by
+`dbtwiz admin backfill` to support non-contiguous task ranges (e.g. retries).""",
+        ),
+    ] = "",
 ) -> None:
     """Build one or more dbt models with interactive selection or exact names."""
     # Validate
@@ -161,6 +172,7 @@ This is automatically set when running via `dbtwiz admin backfill`.""",
         work=work,
         repeat_last=repeat_last,
         backfill=backfill,
+        task_ranges=task_ranges,
     )
 
 

--- a/dbtwiz/commands/build.py
+++ b/dbtwiz/commands/build.py
@@ -26,6 +26,23 @@ def choose_models(target: str, select, repeat_last: bool, work=None):
     return chosen_models
 
 
+def parse_task_ranges(task_ranges: str) -> list[tuple[date, date]]:
+    """Parse a --task-ranges string into a list of (start, end) date pairs.
+
+    Format: "YYYY-MM-DD:YYYY-MM-DD,YYYY-MM-DD:YYYY-MM-DD,..."
+    """
+    ranges: list[tuple[date, date]] = []
+    for piece in task_ranges.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        start_str, end_str = piece.split(":")
+        ranges.append(
+            (date.fromisoformat(start_str.strip()), date.fromisoformat(end_str.strip()))
+        )
+    return ranges
+
+
 def build(
     target: str,
     select: str,
@@ -39,6 +56,7 @@ def build(
     work: bool,
     repeat_last: bool,
     backfill: bool = False,
+    task_ranges: str = "",
 ) -> None:
     """Builds the given models."""
     if target == "dev":
@@ -61,10 +79,19 @@ def build(
     debug(f"Select: '{select}'")
 
     if use_task_index:
-        date_offset = int(os.environ.get("CLOUD_RUN_TASK_INDEX", 0))
-        start_date = start_date + timedelta(days=date_offset * batch_size)
-        end_date = min(end_date, start_date + timedelta(days=batch_size - 1))
-        info(f"Batch size: {batch_size}")
+        task_index = int(os.environ.get("CLOUD_RUN_TASK_INDEX", 0))
+        if task_ranges:
+            ranges = parse_task_ranges(task_ranges)
+            if task_index >= len(ranges):
+                error(
+                    f"Task index {task_index} out of bounds for {len(ranges)} task ranges."
+                )
+                return
+            start_date, end_date = ranges[task_index]
+        else:
+            start_date = start_date + timedelta(days=task_index * batch_size)
+            end_date = min(end_date, start_date + timedelta(days=batch_size - 1))
+            info(f"Batch size: {batch_size}")
 
     info(f"Date range: {start_date} -> {end_date}")
     commands = ["build"]

--- a/dbtwiz/ui/interact.py
+++ b/dbtwiz/ui/interact.py
@@ -7,16 +7,16 @@ from .style import custom_style
 
 def name_validator():
     """Returns the default validator for names."""
-    return (
-        lambda string: (re.match(r"^[a-z][a-z0-9_]*[a-z0-9]$", string) is not None)
+    return lambda string: (
+        (re.match(r"^[a-z][a-z0-9_]*[a-z0-9]$", string) is not None)
         or "The value can only contain lowercase, digits and underscores, must start with a character and not end with underscore"
     )
 
 
 def dataset_name_validator():
     """Returns the validator for dataset names."""
-    return (
-        lambda string: "The value can only contain lowercase, digits, and underscores, and must start with a letter. INFORMATION_SCHEMA is allowed."
+    return lambda string: (
+        "The value can only contain lowercase, digits, and underscores, and must start with a letter. INFORMATION_SCHEMA is allowed."
         if string != "INFORMATION_SCHEMA"
         and not re.match(r"^[a-z][a-z0-9_]*[a-z0-9]$", string)
         else True
@@ -26,21 +26,21 @@ def dataset_name_validator():
 def table_name_validator(dataset_name):
     """Returns the validator for table names."""
     if dataset_name == "INFORMATION_SCHEMA":
-        return (
-            lambda string: re.match(r"^[A-Z][A-Z0-9_]*[A-Z0-9]$", string) is not None
+        return lambda string: (
+            re.match(r"^[A-Z][A-Z0-9_]*[A-Z0-9]$", string) is not None
             or "The table can only contain uppercase, digits and underscores, must start with a character and not end with underscore."
         )
     else:
-        return (
-            lambda string: re.match(r"^[a-z][a-z0-9_]*[a-z0-9]$", string) is not None
+        return lambda string: (
+            re.match(r"^[a-z][a-z0-9_]*[a-z0-9]$", string) is not None
             or "The value can only contain lowercase letters, digits, and underscores, starting with a lowercase letter and not ending with an underscore."
         )
 
 
 def description_validator():
     """Returns the default validator for descriptions."""
-    return (
-        lambda string: (re.match(r"^\S+", string) is not None)
+    return lambda string: (
+        (re.match(r"^\S+", string) is not None)
         or "The description must not start with a space"
     )
 

--- a/docs/admin_backfill.md
+++ b/docs/admin_backfill.md
@@ -3,18 +3,23 @@
 Backfill date-partitioned models in production for a specified date range.
 
 Spawns Cloud Run jobs to process multiple dates in parallel with configurable batch sizes.
+Use --retry to re-run only the failed tasks from the most recent execution.
 
 ## Required arguments
 
 - `select`: Model selector passed to dbt
-- `date_first`: Start of backfill period [YYYY-mm-dd]
+- `date_first`: Start of backfill period [YYYY-mm-dd]. Optional (and ignored) when --retry is set.
 - `date_last`: End of backfill period (inclusive) [YYYY-mm-dd]. Defaults to date_first.
 
 ## Options
 
 ### `--batch-size`, `-b`
 
-Number of dates to include in each batch.
+Number of dates to include in each batch. When used with --retry, subdivides each failed range to this size; if omitted on retry, the failed ranges are retried as-is.
+
+### `--retry`
+
+Retry only the failed tasks from the most recent execution of this backfill job (looked up by selector). When set, date arguments are ignored. Pass --batch-size to subdivide failed ranges before retrying.
 
 ### `--full-refresh`, `-f`
 
@@ -31,6 +36,10 @@ Open job status page in browser after starting execution
 ### `--verbose`, `-v`
 
 Output more info about what is going on
+
+### `--dry-run`
+
+Print the tasks that would be submitted without actually running the job. Works with and without --retry.
 
 ## Examples
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -71,3 +71,11 @@ Pass this option to rebuild the same models that you most recently built.
 
 Sets the dbt variable `is_backfill` to true.
 This is automatically set when running via `dbtwiz admin backfill`.
+
+### `--task-ranges`
+
+Comma-separated list of date ranges, one per task, on the form
+`YYYY-MM-DD:YYYY-MM-DD,YYYY-MM-DD:YYYY-MM-DD,...`. When used together with
+`--use-task-index`, the task picks the range at index `CLOUD_RUN_TASK_INDEX`
+and ignores `--start-date`, `--end-date`, and `--batch-size`. Set by
+`dbtwiz admin backfill` to support non-contiguous task ranges (e.g. retries).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbtwiz"
-version = "0.2.50"
+version = "0.2.51"
 authors = [
     {name = "Amedia Produkt og Teknologi"}
 ]


### PR DESCRIPTION
# feat: add --retry and --dry-run to backfill command

## Problem

When a backfill job has partial failures (e.g. 4 of 29 tasks fail due to transient BigQuery issues), the typical workaround was to re-run the full date range — redundantly reprocessing dates that already succeeded. There was no way to target only the failed tasks.

## Solution

### `--retry`

Retries only the failed tasks from the most recent execution of the backfill job.

```shell
# Retry with the same batch size as the original run
dbtwiz admin backfill my_model --retry

# Retry with a smaller batch size (subdivides failed ranges)
dbtwiz admin backfill my_model --retry --batch-size 5
```

- Looks up the most recent Cloud Run execution for the job (derived from the selector).
- Identifies failed task indices via the Cloud Run v2 REST API.
- Maps failed indices back to their date ranges and submits a **single new job** covering only those ranges — so subsequent retries can again identify failures by task index.
- `--first-date` / `--last-date` are ignored when `--retry` is set (a warning is shown if provided).
- Refuses to retry if the previous execution is still running.
- Backwards compatible: works against jobs submitted before this change (recovers date ranges from the old `--start-date`/`--end-date`/`--batch-size` container args).

### `--dry-run`

Prints the tasks that would be submitted without actually running anything. Works with and without `--retry`.

```shell
# Preview a fresh backfill
dbtwiz admin backfill my_model 2024-01-01 2024-06-30 --dry-run

# Preview a retry
dbtwiz admin backfill my_model --retry --dry-run
```

### `--task-ranges` (internal, `dbtwiz build`)

To support non-contiguous task ranges in a single Cloud Run job, the container entrypoint now accepts `--task-ranges` — a comma-separated list of `YYYY-MM-DD:YYYY-MM-DD` pairs. Each task picks its own range by `CLOUD_RUN_TASK_INDEX`. The old `--start-date`/`--end-date`/`--batch-size` path is kept as a fallback for backwards compatibility.

## Implementation notes

- Per-task status is fetched from the [Cloud Run Admin v2 REST API](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.jobs.executions.tasks) via `google.auth.transport.requests.AuthorizedSession`, consistent with how the rest of the repo calls GCP APIs.
- Selector validation (dbt compile) is skipped on `--retry` — the model was validated when the original job was set up, and the container validates it again at runtime. This makes `--retry` and `--retry --dry-run` near-instant.

## Testing

```shell
# Should report "nothing to retry" (latest execution succeeded)
dbtwiz admin backfill int_subscription__sales_retention --retry --dry-run

# Should report 1 failed task and its date range
dbtwiz admin backfill bsp_subscription__amanda_maran_aggregates --retry --dry-run
```
