### PR TITLE
Fix: allow source create in repos with no existing sources

### DIFF
--- a/dbtwiz/source/create.py
+++ b/dbtwiz/source/create.py
@@ -46,11 +46,17 @@ def select_project(context):
     while True:
         project = context.get("project_name")
         if not project:
-            project = autocomplete_from_list(
-                "What is the project for the source",
-                items=context["projects"],
-                must_exist=False,
-            )
+            if context["projects"]:
+                project = autocomplete_from_list(
+                    "What is the project for the source",
+                    items=context["projects"],
+                    must_exist=False,
+                )
+            else:
+                project = input_text(
+                    "What is the project for the source",
+                    allow_blank=False,
+                )
         exists_check = context["client"].check_project_exists(project)
         if exists_check == "Exists":
             context["project_name"] = project


### PR DESCRIPTION
## Problem

Running `dbtwiz source create` in a repo with no existing source YAML files crashes:

```
ValueError: No choices is given, you should use Text question.
```

`create_source` builds `context["projects"]` from sources discovered under `sources/`:

```python
"projects": sorted(list(set(source["project"] for source in existing_sources))),
```

In a fresh repo (no `sources/` directory yet) this list is empty. `select_project` then calls `autocomplete_from_list` with `items=[]`, and `questionary.autocomplete` refuses to render an empty choice list — so the very first source in any new dbt repo cannot be created interactively.

Closes #158.

## Fix

In `select_project`, fall back to `input_text` when `context["projects"]` is empty. The autocomplete list is purely a convenience over previously-used projects (note `must_exist=False`); with no entries to suggest, plain text input is the correct behaviour. The downstream `check_project_exists` BigQuery call still validates whatever the user enters, so the rest of the flow is unchanged.

```python
if context["projects"]:
    project = autocomplete_from_list(
        "What is the project for the source",
        items=context["projects"],
        must_exist=False,
    )
else:
    project = input_text(
        "What is the project for the source",
        allow_blank=False,
    )
```

## Testing

- In a repo with no `sources/` directory: `dbtwiz source create` now prompts for the project as free-form text instead of crashing, then proceeds through dataset/table selection as normal.
- In a repo with existing sources: behaviour is unchanged — autocomplete over the existing project list still works.
