### PR TITLE
ci: ignore whoami file changes in CI pipelines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Tests
 on:
   pull_request:
     branches: [master]
+    paths-ignore:
+      - "**/whoami.yaml"
+      - "**/whoami*.yaml"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

Configures this repository's GitHub Actions workflows to ignore changes to `whoami` files.

`whoami` files are metadata. This change adds `paths-ignore` so that commits touching only `whoami` files no longer trigger builds or consume build minutes.

The following globs are added to the relevant `pull_request` and `push` (master) triggers:

```yaml
paths-ignore:
  - "**/whoami.yaml"
  - "**/whoami*.yaml"
```

Workflows that already cannot be triggered by `whoami` changes are left untouched: wiki/docs sync workflows use an allowlisted `paths:` filter, cleanup workflows run on PR `closed`, and release/scheduled/comment-triggered workflows are unaffected.

## Breaking changes

None. This only affects which file changes trigger CI; the workflow logic itself is unchanged.

Note: if a build job in this repo is a *required* status check, a PR that touches **only** `whoami` files will skip that workflow and the required check will not report — such a PR will need an admin merge. This is an accepted trade-off of the ADR's `paths-ignore` approach.

## Testing done

- Validated the workflow YAML parses correctly.
- Confirmed the `paths-ignore` globs match the repo's tracked `whoami` file(s) and that no other trigger paths are affected.