### PR TITLE
feature: added dynamic backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ The tool will give you a warning when you run a commmand that needs one of the c
 [tool.dbtwiz.project]
 # Config for default number of days per batch when running backfill
 backfill_default_batch_size = 30
+# Target max gigabytes to scan per batch when auto-calculating batch size.
+# dbtwiz compiles the model and runs a BigQuery dry-run to estimate bytes scanned per day,
+# then sets batch size = floor(backfill_max_bytes_per_batch_gb GB / bytes_per_day).
+# Override with --batch-size to skip auto-calculation entirely.
+backfill_max_bytes_per_batch_gb = 10
 # Config for bucket containing dbt manifest.json at the top level
 bucket_state_project = ""           # Project name for bucket
 bucket_state_identifier = ""        # Bucket name

--- a/README.md
+++ b/README.md
@@ -48,13 +48,9 @@ The tool will give you a warning when you run a commmand that needs one of the c
 
 ```toml
 [tool.dbtwiz.project]
-# Config for default number of days per batch when running backfill
+# Config for default number of days per batch when running backfill.
+# Used as fallback when auto batch size calculation fails.
 backfill_default_batch_size = 30
-# Target max gigabytes to scan per batch when auto-calculating batch size.
-# dbtwiz compiles the model and runs a BigQuery dry-run to estimate bytes scanned per day,
-# then sets batch size = floor(backfill_max_bytes_per_batch_gb GB / bytes_per_day).
-# Override with --batch-size to skip auto-calculation entirely.
-backfill_max_bytes_per_batch_gb = 10
 # Config for bucket containing dbt manifest.json at the top level
 bucket_state_project = ""           # Project name for bucket
 bucket_state_identifier = ""        # Bucket name

--- a/dbtwiz/admin/backfill.py
+++ b/dbtwiz/admin/backfill.py
@@ -37,7 +37,9 @@ def estimate_batch_size(
     from ..integrations.bigquery import GCP_LOCATION, BigQueryClient
     from ..utils.contextmanagers import suppress_output
 
-    client = BigQueryClient()
+    profile = Profile().profile_config("prod")
+    execution_project = profile.get("execution_project")
+    client = BigQueryClient(default_project=execution_project)
     project_root = project_config().root_path()
     sample = sample_date.isoformat()
     min_batch_size = None
@@ -79,7 +81,7 @@ def estimate_batch_size(
                 debug(f"Dry-run returned 0 bytes for {table}, skipping")
                 continue
 
-            batch_size = max(1, int(target_bytes / bytes_per_day))
+            batch_size = min(default_batch_size, max(1, int(target_bytes / bytes_per_day)))
             info(
                 f"Model {table}: {bytes_per_day / 1e9:.2f} GB/day scanned → "
                 f"batch size {batch_size} days (target {target_bytes / 1e9:.0f} GB/batch)"

--- a/dbtwiz/admin/backfill.py
+++ b/dbtwiz/admin/backfill.py
@@ -52,6 +52,7 @@ def estimate_batch_size(
             dbt_args = [
                 "compile",
                 "--select", model_name,
+                "--exclude", "tag:no_backfill",
                 "--target", "prod",
                 "--project-dir", str(project_root),
                 "--vars", f'{{data_interval_start: "{sample}", data_interval_end: "{sample}", is_backfill: true}}',
@@ -579,7 +580,7 @@ def backfill(
         target_bytes = project_config().backfill_max_bytes_per_batch_gb * 10**9
         batch_size = estimate_batch_size(
             models=incremental_models,
-            sample_date=first_date,
+            sample_date=last_date,
             default_batch_size=batch_size,
             target_bytes=target_bytes,
         )

--- a/dbtwiz/admin/backfill.py
+++ b/dbtwiz/admin/backfill.py
@@ -84,7 +84,7 @@ def estimate_batch_size(
 
             batch_size = min(default_batch_size, max(1, int(target_bytes / bytes_per_day)))
             info(
-                f"Model {table}: {bytes_per_day / 1e9:.2f} GB/day scanned → "
+                f"Model {table}: ~{bytes_per_day / 1e9:.2f} GB/day scanned (estimate) → "
                 f"batch size {batch_size} days (target {target_bytes / 1e9:.0f} GB/batch)"
             )
 

--- a/dbtwiz/admin/backfill.py
+++ b/dbtwiz/admin/backfill.py
@@ -576,7 +576,7 @@ def backfill(
         incremental_models = [
             m for m in selected_models if m["config"]["materialized"] == "incremental"
         ]
-        target_bytes = (project_config().backfill_max_bytes_per_batch_gb or 10) * 10**9
+        target_bytes = project_config().backfill_max_bytes_per_batch_gb * 10**9
         batch_size = estimate_batch_size(
             models=incremental_models,
             sample_date=first_date,

--- a/dbtwiz/admin/backfill.py
+++ b/dbtwiz/admin/backfill.py
@@ -577,7 +577,17 @@ def backfill(
         incremental_models = [
             m for m in selected_models if m["config"]["materialized"] == "incremental"
         ]
-        target_bytes = project_config().backfill_max_bytes_per_batch_gb * 10**9
+        # Target bytes per batch is derived from the prod job timeout:
+        #   target = timeout_seconds × assumed_throughput × safety_margin
+        #   = 600s × 0.1 GB/s × 0.8 ≈ 48 GB
+        # The 0.1 GB/s is a conservative throughput assumption for complex models
+        # (joins, rolling windows, aggregations). Simple models will get larger batches
+        # because their dry-run bytes/day will be small, capping at the default batch size.
+        # The safety margin leaves headroom for slot contention and query overhead.
+        timeout_seconds = job_timeout("prod", default=600, leeway=0)
+        assumed_throughput_gbps = 0.1
+        safety_margin = 0.8
+        target_bytes = int(timeout_seconds * assumed_throughput_gbps * 1e9 * safety_margin)
         batch_size = estimate_batch_size(
             models=incremental_models,
             sample_date=last_date,

--- a/dbtwiz/admin/backfill.py
+++ b/dbtwiz/admin/backfill.py
@@ -44,26 +44,26 @@ def estimate_batch_size(
     sample = sample_date.isoformat()
     min_batch_size = None
 
+    dbt_args = [
+        "compile",
+        "--select", " ".join(m["name"] for m in models),
+        "--exclude", "tag:no_backfill",
+        "--target", "prod",
+        "--project-dir", str(project_root),
+        "--vars", f'{{data_interval_start: "{sample}", data_interval_end: "{sample}", is_backfill: true}}',
+    ]
+    with suppress_output():
+        result = dbtRunner().invoke(dbt_args)
+
+    if not result.success:
+        warn("Failed to compile models for batch size estimation, using default batch size")
+        return default_batch_size
+
     for model in models:
         model_name = model["name"]
         table = model.get("alias") or model_name
 
         try:
-            dbt_args = [
-                "compile",
-                "--select", model_name,
-                "--exclude", "tag:no_backfill",
-                "--target", "prod",
-                "--project-dir", str(project_root),
-                "--vars", f'{{data_interval_start: "{sample}", data_interval_end: "{sample}", is_backfill: true}}',
-            ]
-            with suppress_output():
-                result = dbtRunner().invoke(dbt_args)
-
-            if not result.success:
-                warn(f"Failed to compile {table} for batch size estimation, auto-sizing skipped")
-                continue
-
             compiled_files = list(
                 (project_root / "target" / "compiled").glob(f"**/{model_name}.sql")
             )

--- a/dbtwiz/admin/backfill.py
+++ b/dbtwiz/admin/backfill.py
@@ -19,6 +19,85 @@ MAX_CONCURRENT_TASKS = 8
 YAML_FILE = project_dbtwiz_path("backfill-cloudrun.yaml")
 
 
+def estimate_batch_size(
+    models: list[dict],
+    sample_date: date,
+    default_batch_size: int,
+    target_bytes: int,
+) -> int:
+    """Estimate a safe batch size by dry-running each incremental model for a single day.
+
+    Compiles the model SQL against the prod target for sample_date, submits it to
+    BigQuery as a dry-run to get bytes scanned, then calculates a batch size that
+    keeps each task under target_bytes. Falls back to default_batch_size if estimation
+    fails for all models.
+    """
+    from dbt.cli.main import dbtRunner
+
+    from ..integrations.bigquery import GCP_LOCATION, BigQueryClient
+    from ..utils.contextmanagers import suppress_output
+
+    client = BigQueryClient()
+    project_root = project_config().root_path()
+    sample = sample_date.isoformat()
+    min_batch_size = None
+
+    for model in models:
+        model_name = model["name"]
+        table = model.get("alias") or model_name
+
+        try:
+            dbt_args = [
+                "compile",
+                "--select", model_name,
+                "--target", "prod",
+                "--project-dir", str(project_root),
+                "--vars", f'{{data_interval_start: "{sample}", data_interval_end: "{sample}", is_backfill: true}}',
+            ]
+            with suppress_output():
+                result = dbtRunner().invoke(dbt_args)
+
+            if not result.success:
+                warn(f"Failed to compile {table} for batch size estimation, auto-sizing skipped")
+                continue
+
+            compiled_files = list(
+                (project_root / "target" / "compiled").glob(f"**/{model_name}.sql")
+            )
+            if not compiled_files:
+                warn(f"Compiled SQL not found for {table}, auto-sizing skipped")
+                continue
+
+            sql = compiled_files[0].read_text(encoding="utf-8")
+
+            bq = client.get_bigquery()
+            job_config = bq.QueryJobConfig(dry_run=True, use_query_cache=False)
+            job = client.get_client().query(sql, job_config=job_config, location=GCP_LOCATION)
+
+            bytes_per_day = job.total_bytes_processed
+            if not bytes_per_day:
+                debug(f"Dry-run returned 0 bytes for {table}, skipping")
+                continue
+
+            batch_size = max(1, int(target_bytes / bytes_per_day))
+            info(
+                f"Model {table}: {bytes_per_day / 1e9:.2f} GB/day scanned → "
+                f"batch size {batch_size} days (target {target_bytes / 1e9:.0f} GB/batch)"
+            )
+
+            if min_batch_size is None or batch_size < min_batch_size:
+                min_batch_size = batch_size
+
+        except Exception as e:
+            warn(f"Failed to estimate batch size for {table}, auto-sizing skipped: {e}")
+
+    if min_batch_size is None:
+        info(f"No batch size estimate available, using default: {default_batch_size} days")
+        return default_batch_size
+
+    return min_batch_size
+
+
 def chunk_date_range(
     first: date, last: date, batch_size: int
 ) -> list[tuple[date, date]]:
@@ -491,6 +570,17 @@ def backfill(
         if not confirm("Would you still like to run?"):
             return
         first_date = last_date = date.today()
+    elif not batch_size_overridden:
+        incremental_models = [
+            m for m in selected_models if m["config"]["materialized"] == "incremental"
+        ]
+        target_bytes = (project_config().backfill_max_bytes_per_batch_gb or 10) * 10**9
+        batch_size = estimate_batch_size(
+            models=incremental_models,
+            sample_date=first_date,
+            default_batch_size=batch_size,
+            target_bytes=target_bytes,
+        )
 
     ranges = chunk_date_range(first_date, last_date, batch_size)
     job_name = backfill_job_name(selector)

--- a/dbtwiz/config/project.py
+++ b/dbtwiz/config/project.py
@@ -40,6 +40,9 @@ class ProjectConfig(BaseModel):
     backfill_default_batch_size: Optional[int] = Field(
         30, ge=1, le=365, description="Default batch size for backfills"
     )
+    backfill_max_bytes_per_batch_gb: Optional[int] = Field(
+        10, ge=1, description="Target max gigabytes per batch for auto-calculated batch size"
+    )
 
     # Docker settings
     docker_image_url_dbt: Optional[str] = Field(

--- a/dbtwiz/config/project.py
+++ b/dbtwiz/config/project.py
@@ -40,7 +40,7 @@ class ProjectConfig(BaseModel):
     backfill_default_batch_size: Optional[int] = Field(
         30, ge=1, le=365, description="Default batch size for backfills"
     )
-    backfill_max_bytes_per_batch_gb: Optional[int] = Field(
+    backfill_max_bytes_per_batch_gb: int = Field(
         10, ge=1, description="Target max gigabytes per batch for auto-calculated batch size"
     )
 

--- a/dbtwiz/config/project.py
+++ b/dbtwiz/config/project.py
@@ -40,9 +40,7 @@ class ProjectConfig(BaseModel):
     backfill_default_batch_size: Optional[int] = Field(
         30, ge=1, le=365, description="Default batch size for backfills"
     )
-    backfill_max_bytes_per_batch_gb: int = Field(
-        10, ge=1, description="Target max gigabytes per batch for auto-calculated batch size"
-    )
+
 
     # Docker settings
     docker_image_url_dbt: Optional[str] = Field(

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -55,6 +55,9 @@ class TestEstimateBatchSize:
             MagicMock(total_bytes_processed=b) for b in bytes_per_day_list
         ]
 
+        # BigQueryClient is imported lazily inside estimate_batch_size, so patching
+        # at the source module works. If the import ever moves to module top-level
+        # in backfill.py, this must change to "dbtwiz.admin.backfill.BigQueryClient".
         with patch("dbtwiz.integrations.bigquery.BigQueryClient", return_value=mock_bq), \
              patch("dbtwiz.admin.backfill.project_config") as mock_cfg:
             mock_cfg.return_value.root_path.return_value = tmp_path
@@ -89,7 +92,8 @@ class TestEstimateBatchSize:
 
     def test_falls_back_to_default_when_compile_fails(self, tmp_path):
         self.mock_runner.return_value.invoke.return_value.success = False
-        assert self._run([make_model()], tmp_path, []) == self.DEFAULT
+        # Compile failure returns immediately with default, no per-model fallback
+        assert self._run([make_model(), make_model("other")], tmp_path, []) == self.DEFAULT
 
     def test_falls_back_to_default_when_no_compiled_file(self, tmp_path):
         # Do not create the compiled file

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,106 @@
+"""Tests for backfill batch size estimation."""
+
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def make_model(name="my_model", alias=None):
+    return {"name": name, "alias": alias or name, "config": {"materialized": "incremental"}}
+
+
+def write_compiled_sql(tmp_path: Path, model_name: str) -> Path:
+    path = tmp_path / "target" / "compiled" / "project" / "models" / f"{model_name}.sql"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("SELECT 1", encoding="utf-8")
+    return path
+
+
+class TestEstimateBatchSize:
+    DEFAULT = 30
+    TARGET_10GB = 10 * 10**9
+    SAMPLE = date(2024, 1, 31)
+
+    @pytest.fixture(autouse=True)
+    def mock_dbt(self):
+        mock_runner_cls = MagicMock()
+        mock_runner_cls.return_value.invoke.return_value.success = True
+        self.mock_runner = mock_runner_cls
+        mock_module = MagicMock()
+        mock_module.dbtRunner = mock_runner_cls
+        with patch.dict(sys.modules, {"dbt.cli.main": mock_module}):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_suppress(self):
+        with patch("dbtwiz.utils.contextmanagers.suppress_output") as m:
+            m.return_value.__enter__ = MagicMock(return_value=None)
+            m.return_value.__exit__ = MagicMock(return_value=False)
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_profile(self):
+        with patch("dbtwiz.admin.backfill.Profile") as m:
+            m.return_value.profile_config.return_value = {"execution_project": "test-project"}
+            yield
+
+    def _run(self, models, tmp_path, bytes_per_day_list):
+        from dbtwiz.admin.backfill import estimate_batch_size
+
+        mock_bq = MagicMock()
+        mock_bq.get_client.return_value.query.side_effect = [
+            MagicMock(total_bytes_processed=b) for b in bytes_per_day_list
+        ]
+
+        with patch("dbtwiz.integrations.bigquery.BigQueryClient", return_value=mock_bq), \
+             patch("dbtwiz.admin.backfill.project_config") as mock_cfg:
+            mock_cfg.return_value.root_path.return_value = tmp_path
+            return estimate_batch_size(
+                models=models,
+                sample_date=self.SAMPLE,
+                default_batch_size=self.DEFAULT,
+                target_bytes=self.TARGET_10GB,
+            )
+
+    def test_calculates_batch_size_from_dry_run(self, tmp_path):
+        write_compiled_sql(tmp_path, "my_model")
+        assert self._run([make_model()], tmp_path, [2 * 10**9]) == 5  # 10 GB / 2 GB = 5
+
+    def test_floor_division(self, tmp_path):
+        write_compiled_sql(tmp_path, "my_model")
+        assert self._run([make_model()], tmp_path, [3 * 10**9]) == 3  # floor(10 / 3)
+
+    def test_minimum_is_one_when_scan_exceeds_target(self, tmp_path):
+        write_compiled_sql(tmp_path, "my_model")
+        assert self._run([make_model()], tmp_path, [50 * 10**9]) == 1
+
+    def test_uses_minimum_across_models(self, tmp_path):
+        write_compiled_sql(tmp_path, "model_a")
+        write_compiled_sql(tmp_path, "model_b")
+        result = self._run(
+            [make_model("model_a"), make_model("model_b")],
+            tmp_path,
+            [1 * 10**9, 5 * 10**9],  # 10 days and 2 days → min is 2
+        )
+        assert result == 2
+
+    def test_falls_back_to_default_when_compile_fails(self, tmp_path):
+        self.mock_runner.return_value.invoke.return_value.success = False
+        assert self._run([make_model()], tmp_path, []) == self.DEFAULT
+
+    def test_falls_back_to_default_when_no_compiled_file(self, tmp_path):
+        # Do not create the compiled file
+        assert self._run([make_model()], tmp_path, [2 * 10**9]) == self.DEFAULT
+
+    def test_falls_back_to_default_when_dry_run_returns_zero(self, tmp_path):
+        write_compiled_sql(tmp_path, "my_model")
+        assert self._run([make_model()], tmp_path, [0]) == self.DEFAULT
+
+    def test_alias_used_for_display_not_glob(self, tmp_path):
+        # Compiled file is found by model name, not alias
+        write_compiled_sql(tmp_path, "my_model")
+        result = self._run([make_model("my_model", alias="aliased_table")], tmp_path, [2 * 10**9])
+        assert result == 5


### PR DESCRIPTION
This PR added a dynamic function to determine the batch number of days for each backfilling task.

This task is motivated by the fact that the business side sometimes ran into timeout problems when trying to backfill large chunks of data over long period of time in one go.

In this PR, we used the BQ `--dry-run` flag to first do a quick analysis of the **bytes of data scanned** in each partition date, and then calculate the batch number of days for each task in the following way:

`batch_size = min(default_batch_size, max(1, int(target_bytes / bytes_per_day)))`

Here, default_batch_size = 30 as before, target_bytes = 10GB which can be adjusted, bytes_per_day is the result we obtained from the `--dry-run` analysis.

The end result is that, for big tables, the batch number of days for each task should be smaller, meaning that each task will process fewer days of data, and then we increase the number of tasks dynamically to avoid the timeout problem; when it comes the smaller tables, on the other hand, the backfill behaves basically the same as before, with each backfill task processing 30 days of data.